### PR TITLE
Tweak some error strings

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -3,45 +3,34 @@ package main
 import (
 	"bytes"
 	"context"
-	"dario.cat/mergo"
 	"encoding/base64"
-	"fmt"
 	"io"
 
+	"dario.cat/mergo"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
+	"github.com/crossplane/function-sdk-go/errors"
+	"github.com/crossplane/function-sdk-go/logging"
 	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/resource"
-	fn "github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
 
 	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 )
 
-// Function returns whatever response you ask it to.
+// Function uses Go templates to compose resources.
 type Function struct {
 	fnv1beta1.UnimplementedFunctionRunnerServiceServer
 
 	log logging.Logger
 }
-
-const (
-	errFmtInvalidFunction   = "invalid function input: %s"
-	errFmtInvalidReadyValue = "%s is invalid, ready annotation must be True, Unspecified, or False"
-	errFmtInvalidMetaType   = "invalid meta kind %s"
-
-	errCannotGet   = "cannot get the function input"
-	errCannotParse = "cannot parse the provided templates"
-)
 
 const (
 	annotationKeyCompositionResourceName = "gotemplating.fn.crossplane.io/composition-resource-name"
@@ -64,13 +53,13 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 
 	tg, err := NewTemplateSourceGetter(in)
 	if err != nil {
-		response.Fatal(rsp, errors.Wrap(err, fmt.Sprintf(errFmtInvalidFunction, errCannotGet)))
+		response.Fatal(rsp, errors.Wrap(err, "invalid function input"))
 		return rsp, nil
 	}
 
 	tmpl, err := GetNewTemplateWithFunctionMaps().Parse(tg.GetTemplates())
 	if err != nil {
-		response.Fatal(rsp, errors.Wrap(err, fmt.Sprintf(errFmtInvalidFunction, errCannotParse)))
+		response.Fatal(rsp, errors.Wrap(err, "invalid function input: cannot parse the provided templates"))
 		return rsp, nil
 	}
 
@@ -173,7 +162,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 					desiredComposite.ConnectionDetails[k] = d
 				}
 			default:
-				response.Fatal(rsp, fmt.Errorf(errFmtInvalidMetaType, obj.GetKind()))
+				response.Fatal(rsp, errors.Errorf("invalid kind %q for apiVersion %q - must be CompositeConnectionDetails", obj.GetKind(), metaApiVersion))
 				return rsp, nil
 			}
 
@@ -184,11 +173,11 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		// Set ready state.
 		if v, found := cd.Resource.GetAnnotations()[annotationKeyReady]; found {
 			if v != string(resource.ReadyTrue) && v != string(resource.ReadyUnspecified) && v != string(resource.ReadyFalse) {
-				response.Fatal(rsp, fmt.Errorf(fmt.Sprintf(errFmtInvalidFunction, errFmtInvalidReadyValue), v))
+				response.Fatal(rsp, errors.Errorf("invalid function input: invalid %q annotation value %q: must be True, False, or Unspecified", annotationKeyReady, v))
 				return rsp, nil
 			}
 
-			cd.Ready = fn.Ready(v)
+			cd.Ready = resource.Ready(v)
 
 			// Remove meta annotation.
 			meta.RemoveAnnotations(cd.Resource, annotationKeyReady)
@@ -200,7 +189,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		// Add resource to the desired composed resources map.
 		name, found := obj.GetAnnotations()[annotationKeyCompositionResourceName]
 		if !found {
-			response.Fatal(rsp, errors.Errorf("cannot get composition resource name of %s", obj.GetName()))
+			response.Fatal(rsp, errors.Errorf("%q template is missing required %q annotation", obj.GetKind(), annotationKeyCompositionResourceName))
 			return rsp, nil
 		}
 

--- a/fn.go
+++ b/fn.go
@@ -209,7 +209,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		return rsp, nil
 	}
 
-	response.Normalf(rsp, "Successful run with %q source", in.Source)
+	f.log.Info("Successfully composed desired resources", "source", in.Source, "count", len(objs))
 
 	return rsp, nil
 }

--- a/fn_test.go
+++ b/fn_test.go
@@ -209,12 +209,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "nochange", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(xr),
@@ -253,12 +247,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "templates", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(xr),
@@ -297,12 +285,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "status", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(xrWithStatus),
@@ -336,12 +318,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "status", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"foo":"bar","baz":"qux"}}}`),
@@ -375,12 +351,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Tag: "templates", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.FileSystemSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(xr),
@@ -485,12 +455,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(xr),
@@ -567,12 +531,6 @@ func TestRunFunction(t *testing.T) {
 			want: want{
 				rsp: &fnv1beta1.RunFunctionResponse{
 					Meta: &fnv1beta1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
-						{
-							Severity: fnv1beta1.Severity_SEVERITY_NORMAL,
-							Message:  fmt.Sprintf("Successful run with %q source", v1beta1.InlineSource),
-						},
-					},
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource:          resource.MustStructJSON(xr),

--- a/fn_test.go
+++ b/fn_test.go
@@ -71,7 +71,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "invalid function input: cannot get the function input: invalid input source: wrong",
+							Message:  "invalid function input: invalid source: wrong",
 						},
 					},
 				},
@@ -88,7 +88,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "invalid function input: cannot get the function input: invalid input source: ",
+							Message:  "invalid function input: source is required",
 						},
 					},
 				},
@@ -111,7 +111,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "cannot get composition resource name of cool-cd",
+							Message:  "\"CD\" template is missing required \"" + annotationKeyCompositionResourceName + "\" annotation",
 						},
 					},
 				},
@@ -412,7 +412,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "invalid function input: cannot get the function input: cannot read tmpl from the folder {testdata/wrong}: lstat testdata/wrong: no such file or directory",
+							Message:  "invalid function input: cannot read tmpl from the folder {testdata/wrong}: lstat testdata/wrong: no such file or directory",
 						},
 					},
 				},
@@ -445,7 +445,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  fmt.Sprintf(errFmtInvalidFunction, fmt.Sprintf(errFmtInvalidReadyValue, "wrongValue")),
+							Message:  "invalid function input: invalid \"" + annotationKeyReady + "\" annotation value \"wrongValue\": must be True, False, or Unspecified",
 						},
 					},
 					Desired: &fnv1beta1.State{
@@ -532,7 +532,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  fmt.Sprintf(errFmtInvalidMetaType, "InvalidMeta"),
+							Message:  "invalid kind \"InvalidMeta\" for apiVersion \"" + metaApiVersion + "\" - must be CompositeConnectionDetails",
 						},
 					},
 					Desired: &fnv1beta1.State{

--- a/template.go
+++ b/template.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/function-sdk-go/errors"
 
 	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 )
@@ -24,8 +24,10 @@ func NewTemplateSourceGetter(in *v1beta1.Input) (TemplateGetter, error) {
 		return newInlineSource(in)
 	case v1beta1.FileSystemSource:
 		return newFileSource(in)
+	case "":
+		return nil, errors.Errorf("source is required")
 	default:
-		return nil, errors.Errorf("invalid input source: %s", in.Source)
+		return nil, errors.Errorf("invalid source: %s", in.Source)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I noticed that when I was missing the composition-resource-name annotation the error seemed to be missing something. This was because my composed resource template didn't have a metadata.name, and the error was trying to use the name to identify the resource.

It's pretty common to leave out the metadata.name and instead let Crossplane generate one. So instead I've switched to using the Kind to identify the resource. It's not quite as accurate, but it's always required.

While I was in there I tweaked some of the other error strings to provide as much detail as possible. I also removed the error constants pattern, which we're planning to move away from in c/c.

Edit: I also pushed an unrelated commit that removes the call to `response.Normalf` each time the function runs. I've raised https://github.com/crossplane/crossplane/issues/4947 to track documenting that folks shouldn't do this.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
