### PR TITLE
Add a helper function "setResourceNameAnnotation" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ about `crossplane beta render`.
 ## Additional functions
 
 | Name                                                             | Description                                         |
-| ---------------------------------------------------------------- | --------------------------------------------------- |
+|------------------------------------------------------------------| --------------------------------------------------- |
 | [`randomChoice`](example/functions/randomChoice)                 | Randomly selects one of a given strings             |
 | [`toYaml`](example/functions/toYaml)                             | Marshals any object into a YAML string              |
 | [`fromYaml`](example/functions/fromYaml)                         | Unmarshals a YAML string into an object             |
 | [`getResourceCondition`](example/functions/getResourceCondition) | Helper function to retreive conditions of resources |
+| [`setResourceNameAnnotation`](example/functions/inline)          | Returns the special resource-name annotation with given name |
 
 ## Developing this function
 

--- a/example/filesystem/templates.tmpl
+++ b/example/filesystem/templates.tmpl
@@ -19,7 +19,7 @@ apiVersion: iam.aws.upbound.io/v1beta1
 kind: AccessKey
 metadata:
   annotations:
-      gotemplating.fn.crossplane.io/composition-resource-name: sample-access-key-{{ $i }}
+    gotemplating.fn.crossplane.io/composition-resource-name: sample-access-key-{{ $i }}
 spec:
   forProvider:
     userSelector:

--- a/example/inline/composition.yaml
+++ b/example/inline/composition.yaml
@@ -23,7 +23,7 @@ spec:
             kind: User
             metadata:
               annotations:
-                gotemplating.fn.crossplane.io/composition-resource-name: test-user-{{ $i }}
+                {{ setResourceNameAnnotation (print "test-user-" $i) }}
               labels:
                 testing.upbound.io/example-name: test-user-{{ $i }}
               {{ if eq $.observed.resources nil }}
@@ -38,7 +38,7 @@ spec:
             kind: AccessKey
             metadata:
               annotations:
-                  gotemplating.fn.crossplane.io/composition-resource-name: sample-access-key-{{ $i }}
+                {{ setResourceNameAnnotation (print "sample-access-key-" $i) }}
             spec:
               forProvider:
                 userSelector:

--- a/function_maps.go
+++ b/function_maps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"text/template"
 	"time"
@@ -44,6 +45,10 @@ var funcMaps = []template.FuncMap{
 			// Return either found condition or empty one with "Unknown" status
 			cond := conditioned.GetCondition(xpv1.ConditionType(ct))
 			return cond, nil
+		},
+
+		"setResourceNameAnnotation": func(name string) string {
+			return fmt.Sprintf("gotemplating.fn.crossplane.io/composition-resource-name: %s", name)
 		},
 	},
 }

--- a/function_maps_test.go
+++ b/function_maps_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+)
+
+func Test_fromYaml(t *testing.T) {
+	type args struct {
+		val string
+	}
+	type want struct {
+		rsp any
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"UnmarshalYaml": {
+			reason: "Should return unmarshalled yaml",
+			args: args{
+				val: `
+complexDictionary:
+  scalar1: true
+  list:
+  - abc	
+  - def`,
+			},
+			want: want{
+				rsp: map[string]interface{}{
+					"complexDictionary": map[string]interface{}{
+						"scalar1": true,
+						"list": []interface{}{
+							"abc",
+							"def",
+						},
+					},
+				},
+			},
+		},
+		"UnmarshalYamlError": {
+			reason: "Should return error when unmarshalling yaml",
+			args: args{
+				val: `
+complexDictionary:
+	  scalar1: true
+`,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := fromYaml(tc.args.val)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nfromYaml(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nfromYaml(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func Test_toYaml(t *testing.T) {
+	type args struct {
+		val any
+	}
+	type want struct {
+		rsp any
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MarshalYaml": {
+			reason: "Should return marshalled yaml",
+			args: args{
+				val: map[string]interface{}{
+					"complexDictionary": map[string]interface{}{
+						"scalar1": true,
+						"list": []interface{}{
+							"abc",
+							"def",
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: `complexDictionary:
+    list:
+        - abc
+        - def
+    scalar1: true
+`,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := toYaml(tc.args.val)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\ntoYaml(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\ntoYaml(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func Test_getResourceCondition(t *testing.T) {
+	type args struct {
+		ct  string
+		res map[string]any
+	}
+
+	type want struct {
+		rsp v1.Condition
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"GetCondition": {
+			reason: "Should return condition",
+			args: args{
+				ct: "Ready",
+				res: map[string]any{
+					"resource": map[string]any{
+						"status": map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: v1.Condition{
+					Type:   "Ready",
+					Status: "True",
+				},
+			},
+		},
+		"GetConditionUnknown": {
+			reason: "Should return an Unknown status",
+			args: args{
+				ct: "Ready",
+				res: map[string]any{
+					"resource": map[string]any{},
+				},
+			},
+			want: want{
+				rsp: v1.Condition{
+					Type:   "Ready",
+					Status: "Unknown",
+				},
+			},
+		},
+		"GetConditionNotFound": {
+			reason: "Should return an Unknown condition when not found",
+			args: args{
+				ct: "Ready",
+				res: map[string]any{
+					"resource": map[string]any{
+						"status": map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   "NotReady",
+									"status": "True",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: v1.Condition{
+					Type:   "Ready",
+					Status: "Unknown",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp := getResourceCondition(tc.args.ct, tc.args.res)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\ngetResourceCondition(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func Test_setResourceNameAnnotation(t *testing.T) {
+	type args struct {
+		name string
+	}
+	type want struct {
+		rsp string
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"SetAnnotationWithGivenName": {
+			reason: "Should return composition resource name annotation with given name",
+			args: args{
+				name: "test",
+			},
+			want: want{
+				rsp: "gotemplating.fn.crossplane.io/composition-resource-name: test",
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp := setResourceNameAnnotation(tc.args.name)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nsetResourceNameAnnotation(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR introduces a new helper function "setResourceNameAnnotation" which returns the special resource-name annotation. 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #26 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
