### PR TITLE
include note in README for base64 encoding connection secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ data:
 apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
 kind: CompositeConnectionDetails
 data:
-  server-endpoint: {{ b64enc ((index $.observed.resources "my-server").resource.status.atProvider.endpoint) }}
+  server-endpoint: {{ (index $.observed.resources "my-server").resource.status.atProvider.endpoint | b64enc }}
 ```
 
 To mark a desired composed resource as ready, use the

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ data:
   connection-secret-key: connection-secret-value
 ```
 
+> Note: The value of the connection secret value must be base64 encoded. This is already the case if you are referencing a key from a mananged resource's `connectionDetails` field. However, if you want to include a connection secret value from somewhere else, you will need to use the `b64enc` Sprig function:
+```yaml
+apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+kind: CompositeConnectionDetails
+data:
+  server-endpoint: {{ b64enc ((index $.observed.resources "my-server").resource.status.atProvider.endpoint) }}
+```
+
 To mark a desired composed resource as ready, use the
 `gotemplating.fn.crossplane.io/ready` annotation:
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Includes a note in the documentation to explain that the keys in the `CompositeConnectionDetails` resource must be base64 encoded. This is particularly useful when trying to include a connection secret value from somewhere other than a managed resource's `connectionDetails` field.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
