### PR TITLE
skip hidden dirs for FileSource

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -57,6 +57,8 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		return rsp, nil
 	}
 
+	f.log.Debug("template", "template", tg.GetTemplates())
+
 	tmpl, err := GetNewTemplateWithFunctionMaps(in.Delims).Parse(tg.GetTemplates())
 	if err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "invalid function input: cannot parse the provided templates"))

--- a/template.go
+++ b/template.go
@@ -83,9 +83,19 @@ func newFileSource(in *v1beta1.GoTemplate) (*FileSource, error) {
 func readTemplates(dir string) (string, error) {
 	tmpl := ""
 
-	if err := filepath.Walk(dir, func(path string, info os.FileInfo, e error) error {
+	if err := filepath.WalkDir(dir, func(path string, dirEntry os.DirEntry, e error) error {
 		if e != nil {
 			return e
+		}
+
+		// skip hidden directories
+		if dirEntry.IsDir() && dirEntry.Name()[0] == dotCharacter {
+			return filepath.SkipDir
+		}
+
+		info, err := dirEntry.Info()
+		if err != nil {
+			return err
 		}
 
 		// check for directory and hidden files/folders

--- a/testdata/templates/..shouldBeSkipped/_helpers.tpl
+++ b/testdata/templates/..shouldBeSkipped/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "common-labels" -}}
+testLabel: "testValue"
+{{- end }}

--- a/testdata/templates/..shouldBeSkipped/resource.yaml
+++ b/testdata/templates/..shouldBeSkipped/resource.yaml
@@ -1,0 +1,23 @@
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  annotations:
+    gotemplating.fn.crossplane.io/composition-resource-name: test
+  labels:
+    {{- include "common-labels" . | nindent 4}}
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    manifest:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-001
+        namespace: test
+        labels:
+          {{- include "common-labels" . | nindent 10}}
+      data:
+        test: |
+          spec:
+            resources: []


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #56 in which for FileSource templates, mounted from a Configmap, the function was throwing errors like:
```
cannot compose resources: pipeline step "render-templates" returned a fatal result: invalid function input: cannot parse the provided templates: template: manifests:33: template: multiple definition of template "common-labels"
```

When debugging, noticed that actually it was happening because the template files were read twice. This is due to the structure of ConfigMap/Secret mounted files which looks somewhat like this:
```
ls -lA
total 0
drwxr-xr-x@ 4 lsviben  staff  128 Jan 16 09:37 ..2024_01_16_08_37_36.1811124794
lrwxr-xr-x@ 1 lsviben  staff   32 Jan 16 09:37 ..data -> ..2024_01_16_08_37_36.1811124794
lrwxr-xr-x@ 1 lsviben  staff   19 Jan 16 09:37 _helpers.tpl -> ..data/_helpers.tpl
lrwxr-xr-x@ 1 lsviben  staff   20 Jan 16 09:37 resource.yaml -> ..data/resource.yaml

ls -lA ..2024_01_16_08_37_36.1811124794
total 16
drwxr-xr-x@ 4 lsviben  staff  128 Jan 16 09:37 .
drwxr-xr-x@ 6 lsviben  staff  192 Jan 16 09:37 ..
-rw-r--r--@ 1 lsviben  staff  271 Jan 16 09:37 _helpers.tpl
-rw-r--r--@ 1 lsviben  staff  538 Jan 16 09:37 resource.yaml

```
This is so that the configmap files can be updated on the fly.

So the `filepath.Walk` which is used in the function to go through the files would read every file, in both the root directory and the ..2024.. dir. 

Changing to `filepath.WalkDir` which first reads the directory and allows us to decide if we want to enter it, with skipping hidden dirs fixes this issue. 

Added a similar structure to the unit test + tested with the reproduction steps on #56 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #56 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
