### PR TITLE
Remove sprig's env and expandenv functions

### DIFF
--- a/function_maps.go
+++ b/function_maps.go
@@ -41,9 +41,15 @@ func GetNewTemplateWithFunctionMaps(delims *v1beta1.Delims) *template.Template {
 		tpl.Funcs(f)
 	}
 	tpl.Funcs(template.FuncMap{
-			"include": initInclude(tpl),
+		"include": initInclude(tpl),
 	})
-	tpl.Funcs(sprig.FuncMap())
+	// Sprig's env and expandenv can lead to information leakage (injected tokens/passwords).
+	// Both Helm and ArgoCD remove these due to security implications.
+	// see: https://masterminds.github.io/sprig/os.html
+	sprigFuncs := sprig.FuncMap()
+	delete(sprigFuncs, "env")
+	delete(sprigFuncs, "expandenv")
+	tpl.Funcs(sprigFuncs)
 
 	return tpl
 }


### PR DESCRIPTION
Both Helm and ArgoCD remove access to these two due to security implications. It's possible to retrieve the function's pod environmental values. Some of these might be sensitive.

See more:

https://masterminds.github.io/sprig/os.html
https://github.com/argoproj/argo-workflows/pull/5850 https://github.com/helm/helm/blob/e81f6140ddb22bc99a08f7409522a8dbe5338ee3/pkg/engine/funcs.go#L45

Also ran a go fmt.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #67 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
