### PR TITLE
feat: add extra resources support

### DIFF
--- a/example/extra-resources/composition.yaml
+++ b/example/extra-resources/composition.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-extra-resources
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              bucket:
+                apiVersion: s3.aws.upbound.io/v1beta1
+                kind: Bucket
+                matchName: my-awesome-{{ .observed.composite.resource.spec.environment }}-bucket
+            {{ with index (default (dig "some-foo-by-name" "items" .extraResources)) 0 }}
+            {{ $bucketName := index . "resource" "status" "atProvider" "id" }}
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: CompositeConnectionDetails
+            data:
+              BUCKET_NAME: {{ $bucketName | b64enc }}
+            {{- end }}
+            ---
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            status:
+              dummy: cool-status

--- a/example/extra-resources/composition.yaml
+++ b/example/extra-resources/composition.yaml
@@ -25,13 +25,27 @@ spec:
                 apiVersion: s3.aws.upbound.io/v1beta1
                 kind: Bucket
                 matchName: my-awesome-{{ .observed.composite.resource.spec.environment }}-bucket
-            {{ with index (default (dig "some-foo-by-name" "items" .extraResources)) 0 }}
-            {{ $bucketName := index . "resource" "status" "atProvider" "id" }}
+            {{- with .extraResources }}
+            {{ $someExtraResources := index . "bucket" }}
+            {{- range $i, $extraResource := $someExtraResources.items }}
             ---
-            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
-            kind: CompositeConnectionDetails
-            data:
-              BUCKET_NAME: {{ $bucketName | b64enc }}
+            apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            metadata:
+              annotations: 
+                gotemplating.fn.crossplane.io/composition-resource-name: bucket-configmap-{{ $i }}
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Configmap
+                  metadata:
+                    name: {{ $extraResource.resource.metadata.name }}-bucket
+                  data:
+                    bucket: {{ $extraResource.resource.status.atProvider.id }} 
+              providerConfigRef:
+                name: "kubernetes"
+            {{- end }}
             {{- end }}
             ---
             apiVersion: example.crossplane.io/v1beta1

--- a/example/extra-resources/extraResources.yaml
+++ b/example/extra-resources/extraResources.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  labels:
+    testing.upbound.io/example-name: bucket-notification
+  name: my-awesome-dev-bucket
+spec:
+  forProvider:
+    region: us-west-1
+status:
+  atProvider:
+    id: random-bucket-id

--- a/example/extra-resources/functions.yaml
+++ b/example/extra-resources/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.1

--- a/example/extra-resources/functions.yaml
+++ b/example/extra-resources/functions.yaml
@@ -2,5 +2,8 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-go-templating
+  annotations:
+    render.crossplane.io/runtime: "Development"
+    render.crossplane.io/runtime-development-target: "localhost:9443"
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.1

--- a/example/extra-resources/functions.yaml
+++ b/example/extra-resources/functions.yaml
@@ -2,8 +2,5 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-go-templating
-  annotations:
-    render.crossplane.io/runtime: "Development"
-    render.crossplane.io/runtime-development-target: "localhost:9443"
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.1

--- a/example/extra-resources/xr.yaml
+++ b/example/extra-resources/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  environment: dev

--- a/extraresources.go
+++ b/extraresources.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
+)
+
+// ExtraResourcesRequirements defines the requirements for extra resources.
+type ExtraResourcesRequirements map[string]ExtraResourcesRequirement
+
+// ExtraResourcesRequirement defines a single requirement for extra resources.
+// Needed to have camelCase keys instead of the snake_case keys as defined
+// through json tags by fnv1beta1.ResourceSelector.
+type ExtraResourcesRequirement struct {
+	// APIVersion of the resource.
+	APIVersion string `json:"apiVersion"`
+	// Kind of the resource.
+	Kind string `json:"kind"`
+	// MatchLabels defines the labels to match the resource, if defined,
+	// matchName is ignored.
+	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+	// MatchName defines the name to match the resource, if MatchLabels is
+	// empty.
+	MatchName string `json:"matchName,omitempty"`
+}
+
+// ToResourceSelector converts the ExtraResourcesRequirement to a fnv1beta1.ResourceSelector.
+func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1beta1.ResourceSelector {
+	out := &fnv1beta1.ResourceSelector{
+		ApiVersion: e.APIVersion,
+		Kind:       e.Kind,
+	}
+	if len(e.MatchLabels) == 0 {
+		out.Match = &fnv1beta1.ResourceSelector_MatchName{
+			MatchName: e.MatchName,
+		}
+		return out
+	}
+
+	out.Match = &fnv1beta1.ResourceSelector_MatchLabels{
+		MatchLabels: &fnv1beta1.MatchLabels{Labels: e.MatchLabels},
+	}
+	return out
+}

--- a/extraresources.go
+++ b/extraresources.go
@@ -29,15 +29,15 @@ func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1beta1.ResourceSele
 		ApiVersion: e.APIVersion,
 		Kind:       e.Kind,
 	}
-	if len(e.MatchLabels) == 0 {
-		out.Match = &fnv1beta1.ResourceSelector_MatchName{
-			MatchName: e.MatchName,
+	if e.MatchName == "" {
+		out.Match = &fnv1beta1.ResourceSelector_MatchLabels{
+			MatchLabels: &fnv1beta1.MatchLabels{Labels: e.MatchLabels},
 		}
 		return out
 	}
 
-	out.Match = &fnv1beta1.ResourceSelector_MatchLabels{
-		MatchLabels: &fnv1beta1.MatchLabels{Labels: e.MatchLabels},
+	out.Match = &fnv1beta1.ResourceSelector_MatchName{
+		MatchName: e.MatchName,
 	}
 	return out
 }

--- a/fn.go
+++ b/fn.go
@@ -204,7 +204,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 					requirements.ExtraResources[k] = v.ToResourceSelector()
 				}
 			default:
-				response.Fatal(rsp, errors.Errorf("invalid kind %q for apiVersion %q - must be CompositeConnectionDetails", obj.GetKind(), metaApiVersion))
+				response.Fatal(rsp, errors.Errorf("invalid kind %q for apiVersion %q - must be CompositeConnectionDetails or ExtraResources", obj.GetKind(), metaApiVersion))
 				return rsp, nil
 			}
 

--- a/fn_test.go
+++ b/fn_test.go
@@ -594,7 +594,7 @@ func TestRunFunction(t *testing.T) {
 			},
 		},
 		"ExtraResources": {
-			reason: "The Function should return a fatal result if the extra resource key is duplicated.",
+			reason: "The Function should return the desired composite with extra resources.",
 			args: args{
 				req: &fnv1beta1.RunFunctionRequest{
 					Input: resource.MustStructObject(

--- a/fn_test.go
+++ b/fn_test.go
@@ -37,6 +37,11 @@ var (
 	xrWithNestedStatusFoo = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"foo":"bar"}}}`
 	xrWithNestedStatusBaz = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"baz":"qux"}}}`
 
+	extraResources = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
+{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{"key": "value"}},"yet-another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"foo"}}}`
+	extraResourcesDuplicatedKey = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
+{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"another-cool-extra-resource"}}}`
+
 	path      = "testdata/templates"
 	wrongPath = "testdata/wrong"
 
@@ -582,6 +587,124 @@ func TestRunFunction(t *testing.T) {
 						Composite: &fnv1beta1.Resource{
 							Resource:          resource.MustStructJSON(xr),
 							ConnectionDetails: map[string][]byte{"key": []byte("value")},
+						},
+					},
+				},
+			},
+		},
+		"ExtraResources": {
+			reason: "The Function should return a fatal result if the extra resource key is duplicated.",
+			args: args{
+				req: &fnv1beta1.RunFunctionRequest{
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: extraResources},
+						}),
+					Observed: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"cool-cd": {
+								Resource: resource.MustStructJSON(cd),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1beta1.RunFunctionResponse{
+					Meta:    &fnv1beta1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1beta1.Result{},
+					Requirements: &fnv1beta1.Requirements{
+						ExtraResources: map[string]*fnv1beta1.ResourceSelector{
+							"cool-extra-resource": {
+								ApiVersion: "example.org/v1",
+								Kind:       "CoolExtraResource",
+								Match: &fnv1beta1.ResourceSelector_MatchName{
+									MatchName: "cool-extra-resource",
+								},
+							},
+							"another-cool-extra-resource": {
+								ApiVersion: "example.org/v1",
+								Kind:       "CoolExtraResource",
+								Match: &fnv1beta1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1beta1.MatchLabels{
+										Labels: map[string]string{"key": "value"},
+									},
+								},
+							},
+							"yet-another-cool-extra-resource": {
+								ApiVersion: "example.org/v1",
+								Kind:       "CoolExtraResource",
+								Match: &fnv1beta1.ResourceSelector_MatchName{
+									MatchName: "foo",
+								},
+							},
+						},
+					},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"cool-cd": {
+								Resource: resource.MustStructJSON(cd),
+							},
+						},
+					},
+				},
+			},
+		},
+		"DuplicateExtraResourceKey": {
+			reason: "The Function should return a fatal result if the extra resource key is duplicated.",
+			args: args{
+				req: &fnv1beta1.RunFunctionRequest{
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: extraResourcesDuplicatedKey},
+						}),
+					Observed: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"cool-cd": {
+								Resource: resource.MustStructJSON(cd),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1beta1.RunFunctionResponse{
+					Meta: &fnv1beta1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1beta1.Result{
+						{
+							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
+							Message:  "duplicate extra resource key \"cool-extra-resource\"",
+						},
+					},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"cool-cd": {
+								Resource: resource.MustStructJSON(cd),
+							},
 						},
 					},
 				},

--- a/fn_test.go
+++ b/fn_test.go
@@ -38,7 +38,8 @@ var (
 	xrWithNestedStatusBaz = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"baz":"qux"}}}`
 
 	extraResources = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
-{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{"key": "value"}},"yet-another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"foo"}}}`
+{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{"key": "value"}},"yet-another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"foo"}}}
+{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"all-cool-resources":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{}}}}`
 	extraResourcesDuplicatedKey = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"another-cool-extra-resource"}}}`
 
@@ -645,6 +646,15 @@ func TestRunFunction(t *testing.T) {
 								Kind:       "CoolExtraResource",
 								Match: &fnv1beta1.ResourceSelector_MatchName{
 									MatchName: "foo",
+								},
+							},
+							"all-cool-resources": {
+								ApiVersion: "example.org/v1",
+								Kind:       "CoolExtraResource",
+								Match: &fnv1beta1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1beta1.MatchLabels{
+										Labels: map[string]string{},
+									},
 								},
 							},
 						},

--- a/fn_test.go
+++ b/fn_test.go
@@ -549,7 +549,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1beta1.Result{
 						{
 							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
-							Message:  "invalid kind \"InvalidMeta\" for apiVersion \"" + metaApiVersion + "\" - must be CompositeConnectionDetails",
+							Message:  "invalid kind \"InvalidMeta\" for apiVersion \"" + metaApiVersion + "\" - must be CompositeConnectionDetails or ExtraResources",
 						},
 					},
 					Desired: &fnv1beta1.State{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #77
 
Testing example:
```sh
$ go run ./... --debug --insecure &
$ cd example/extra-resources/
# add back the annotations to run the local 
#   annotations:
#     render.crossplane.io/runtime: "Development"
#     render.crossplane.io/runtime-development-target: "localhost:9443"
$ crossplane beta render xr.yaml composition.yaml functions.yaml --extra-resources extraResources.yaml -r
---
apiVersion: example.crossplane.io/v1beta1
kind: XR
metadata:
  name: example
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: bucket-configmap-0'
    reason: Creating
    status: "False"
    type: Ready
  dummy: cool-status
---
apiVersion: kubernetes.crossplane.io/v1alpha1
kind: Object
metadata:
  annotations:
    crossplane.io/composition-resource-name: bucket-configmap-0
  generateName: example-
  labels:
    crossplane.io/composite: example
  ownerReferences:
  - apiVersion: example.crossplane.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: XR
    name: example
    uid: ""
spec:
  forProvider:
    manifest:
      apiVersion: v1
      data:
        bucket: random-bucket-id
      kind: Configmap
      metadata:
        name: my-awesome-dev-bucket-bucket
  providerConfigRef:
    name: kubernetes
```

Once this pr is merged and a release is cut, renovate will bump the image pointed by the example.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
