### PR TITLE
fix(README): Added quotes to the ready annotation value

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ kind: Bucket
 metadata:
   annotations:
     gotemplating.fn.crossplane.io/composition-resource-name: bucket
-    gotemplating.fn.crossplane.io/ready: True
+    gotemplating.fn.crossplane.io/ready: "True"
 spec: {}
 ```
 


### PR DESCRIPTION
### Description of your changes
Added quotes to the "True" value in the example of resource readiness.

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
