### PR TITLE
Support creating composed resources with the composite resource's type (recursion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ For more information, see the example in [context](example/context).
 
 ### Updating status or creating composed resources with the composite resource's type
 
-By default this function **does not create composed resources** with the composite resource's type. If a resource with the composite resource's type is found in the template, then only the composite resource's **status is updated**.
+This function applies special logic if a resource with the composite resource's type is found in the template.
+
+If the resource name is not set (the `gotemplating.fn.crossplane.io/composition-resource-name` meta annotation is not present), then the function **does not create composed resources** with the composite resource's type. In this case only the composite resource's **status is updated**.
 
 For example, the following composition does not create composed resources. Rather, it updates the composite resource's status to include `dummy: cool-status`.
 
@@ -236,7 +238,7 @@ spec:
               dummy: cool-status
 ```
 
-If necessary, this functionality can be changed so that the function **creates composed resources** with the composite resource's type. To enable this, the `gotemplating.fn.crossplane.io/allow-recursion` meta annotation must be used.
+On the other hand, if the resource name is set (using the `gotemplating.fn.crossplane.io/composition-resource-name` meta annotation), then  the function **creates composed resources** with the composite resource's type.
 
 For example, the following composition will create a composed resource:
 
@@ -264,7 +266,6 @@ spec:
             kind: XR
             metadata:
               annotations:
-                "gotemplating.fn.crossplane.io/allow-recursion": "true"
                 {{ setResourceNameAnnotation "recursive-xr" }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,72 @@ data:
 
 For more information, see the example in [context](example/context).
 
+### Updating status or creating composed resources with the composite resource's type
+
+By default this function **does not create composed resources** with the composite resource's type. If a resource with the composite resource's type is found in the template, then only the composite resource's **status is updated**.
+
+For example, the following composition does not create composed resources. Rather, it updates the composite resource's status to include `dummy: cool-status`.
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-update-status
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            status:
+              dummy: cool-status
+```
+
+If necessary, this functionality can be changed so that the function **creates composed resources** with the composite resource's type. To enable this, the `gotemplating.fn.crossplane.io/allow-recursion` meta annotation must be used.
+
+For example, the following composition will create a composed resource:
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-allow-recursion
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            metadata:
+              annotations:
+                "gotemplating.fn.crossplane.io/allow-recursion": "true"
+                {{ setResourceNameAnnotation "recursive-xr" }}
+```
+
+For more information, see the example in [recursive](example/recursive).
+
 ## Additional functions
 
 | Name                                                             | Description                                                  |

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ spec:
               dummy: cool-status
 ```
 
-On the other hand, if the resource name is set (using the `gotemplating.fn.crossplane.io/composition-resource-name` meta annotation), then  the function **creates composed resources** with the composite resource's type.
+On the other hand, if the resource name is set (using the `gotemplating.fn.crossplane.io/composition-resource-name` meta annotation), then the function **creates composed resources** with the composite resource's type.
 
 For example, the following composition will create a composed resource:
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,12 @@ spec:
             metadata:
               annotations:
                 {{ setResourceNameAnnotation "recursive-xr" }}
+            spec:
+              compositionRef:
+                name: example-other # make sure to avoid infinite recursion
 ```
+
+> :warning: _Caution: this usage can lead to infinite recursion. Make sure to terminate the recursion by specifying a different `compositionRef` at some point._
 
 For more information, see the example in [recursive](example/recursive).
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ spec:
                 name: example-other # make sure to avoid infinite recursion
 ```
 
-> :warning: _Caution: this usage can lead to infinite recursion. Make sure to terminate the recursion by specifying a different `compositionRef` at some point._
+> [!WARNING]
+> This can lead to infinite recursion. Make sure to terminate the recursion by specifying a different `compositionRef` at some point.
 
 For more information, see the example in [recursive](example/recursive).
 

--- a/example/recursive/composition-real.yaml
+++ b/example/recursive/composition-real.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-recursive-real # defining the real composition
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: s3.aws.upbound.io/v1beta1
+            kind: Bucket
+            metadata:
+              annotations:
+                {{ setResourceNameAnnotation "bucket" }}
+            spec:
+              forProvider:
+                region: {{ .observed.composite.resource.spec.region }}

--- a/example/recursive/composition-wrapper.yaml
+++ b/example/recursive/composition-wrapper.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: example-recursive
+  name: example-recursive-wrapper # defining the wrapper composition
 spec:
   compositeTypeRef:
     apiVersion: example.crossplane.io/v1beta1
@@ -24,4 +24,8 @@ spec:
             metadata:
               annotations:
                 {{ setResourceNameAnnotation (print "test-xr-" $i) }}
+            spec:
+              compositionRef:
+                name: example-recursive-real # instantiating the real composition
+              region: {{ print "us-west-" (add $i 1) }}
             {{ end }}

--- a/example/recursive/composition.yaml
+++ b/example/recursive/composition.yaml
@@ -26,4 +26,3 @@ spec:
                 "gotemplating.fn.crossplane.io/allow-recursion": "true"
                 {{ setResourceNameAnnotation (print "test-xr-" $i) }}
             {{ end }}
-            

--- a/example/recursive/composition.yaml
+++ b/example/recursive/composition.yaml
@@ -23,6 +23,5 @@ spec:
             kind: XR
             metadata:
               annotations:
-                "gotemplating.fn.crossplane.io/allow-recursion": "true"
                 {{ setResourceNameAnnotation (print "test-xr-" $i) }}
             {{ end }}

--- a/example/recursive/composition.yaml
+++ b/example/recursive/composition.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-recursive
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- range $i := until ( .observed.composite.resource.spec.count | int ) }}
+            ---
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            metadata:
+              annotations:
+                "gotemplating.fn.crossplane.io/allow-recursion": "true"
+                {{ setResourceNameAnnotation (print "test-xr-" $i) }}
+            {{ end }}
+            

--- a/example/recursive/functions.yaml
+++ b/example/recursive/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.5.0

--- a/example/recursive/xr.yaml
+++ b/example/recursive/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  count: 2

--- a/example/recursive/xr.yaml
+++ b/example/recursive/xr.yaml
@@ -3,4 +3,6 @@ kind: XR
 metadata:
   name: example
 spec:
+  compositionRef:
+    name: example-recursive-wrapper # instantiating the wrapper composition
   count: 2

--- a/fn.go
+++ b/fn.go
@@ -47,6 +47,7 @@ type Function struct {
 const (
 	annotationKeyCompositionResourceName = "gotemplating.fn.crossplane.io/composition-resource-name"
 	annotationKeyReady                   = "gotemplating.fn.crossplane.io/ready"
+	annotationKeyAllowRecursion          = "gotemplating.fn.crossplane.io/allow-recursion"
 
 	metaApiVersion = "meta.gotemplating.fn.crossplane.io/v1alpha1"
 )
@@ -153,31 +154,37 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		cd.Resource.Unstructured = *obj.DeepCopy()
 
 		// TODO(ezgidemirel): Refactor to reduce cyclomatic complexity.
-		// Update only the status of the desired composite resource.
+		// Handle if the composite resource appears in the rendered template.
 		if cd.Resource.GetAPIVersion() == observedComposite.Resource.GetAPIVersion() && cd.Resource.GetKind() == observedComposite.Resource.GetKind() {
-			dst := make(map[string]any)
-			if err := desiredComposite.Resource.GetValueInto("status", &dst); err != nil && !fieldpath.IsNotFound(err) {
-				response.Fatal(rsp, errors.Wrap(err, "cannot get desired composite status"))
-				return rsp, nil
-			}
+			// Allow recursion if requested in meta annotation.
+			if _, found := cd.Resource.GetAnnotations()[annotationKeyAllowRecursion]; found {
+				// Remove meta annotation.
+				meta.RemoveAnnotations(cd.Resource, annotationKeyAllowRecursion)
+			} else { // Otherwise, update only the status of the desired composite resource.
+				dst := make(map[string]any)
+				if err := desiredComposite.Resource.GetValueInto("status", &dst); err != nil && !fieldpath.IsNotFound(err) {
+					response.Fatal(rsp, errors.Wrap(err, "cannot get desired composite status"))
+					return rsp, nil
+				}
 
-			src := make(map[string]any)
-			if err := cd.Resource.GetValueInto("status", &src); err != nil && !fieldpath.IsNotFound(err) {
-				response.Fatal(rsp, errors.Wrap(err, "cannot get templated composite status"))
-				return rsp, nil
-			}
+				src := make(map[string]any)
+				if err := cd.Resource.GetValueInto("status", &src); err != nil && !fieldpath.IsNotFound(err) {
+					response.Fatal(rsp, errors.Wrap(err, "cannot get templated composite status"))
+					return rsp, nil
+				}
 
-			if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
-				response.Fatal(rsp, errors.Wrap(err, "cannot merge desired composite status"))
-				return rsp, nil
-			}
+				if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+					response.Fatal(rsp, errors.Wrap(err, "cannot merge desired composite status"))
+					return rsp, nil
+				}
 
-			if err := fieldpath.Pave(desiredComposite.Resource.Object).SetValue("status", dst); err != nil {
-				response.Fatal(rsp, errors.Wrap(err, "cannot set desired composite status"))
-				return rsp, nil
-			}
+				if err := fieldpath.Pave(desiredComposite.Resource.Object).SetValue("status", dst); err != nil {
+					response.Fatal(rsp, errors.Wrap(err, "cannot set desired composite status"))
+					return rsp, nil
+				}
 
-			continue
+				continue
+			}
 		}
 
 		// TODO(ezgidemirel): Refactor to reduce cyclomatic complexity.

--- a/fn_test.go
+++ b/fn_test.go
@@ -38,7 +38,7 @@ var (
 	xrWithStatus          = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"ready":"true"}}`
 	xrWithNestedStatusFoo = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"foo":"bar"}}}`
 	xrWithNestedStatusBaz = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"baz":"qux"}}}`
-	xrRecursiveTmpl       = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/composition-resource-name":"recursive-xr","gotemplating.fn.crossplane.io/allow-recursion":"true"},"name":"recursive-xr","labels":{"belongsTo":{{.observed.composite.resource.metadata.name|quote}}}},"spec":{"count":2}}`
+	xrRecursiveTmpl       = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/composition-resource-name":"recursive-xr"},"name":"recursive-xr","labels":{"belongsTo":{{.observed.composite.resource.metadata.name|quote}}}},"spec":{"count":2}}`
 
 	extraResources = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{"key": "value"}},"yet-another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"foo"}}}

--- a/fn_test.go
+++ b/fn_test.go
@@ -38,6 +38,7 @@ var (
 	xrWithStatus          = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"ready":"true"}}`
 	xrWithNestedStatusFoo = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"foo":"bar"}}}`
 	xrWithNestedStatusBaz = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"baz":"qux"}}}`
+	xrRecursiveTmpl       = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/composition-resource-name":"recursive-xr","gotemplating.fn.crossplane.io/allow-recursion":"true"},"name":"recursive-xr","labels":{"belongsTo":{{.observed.composite.resource.metadata.name|quote}}}},"spec":{"count":2}}`
 
 	extraResources = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{"key": "value"}},"yet-another-cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"foo"}}}
@@ -376,6 +377,44 @@ func TestRunFunction(t *testing.T) {
 					Desired: &fnv1beta1.State{
 						Composite: &fnv1beta1.Resource{
 							Resource: resource.MustStructJSON(`{"apiVersion":"example.org/v1","kind":"XR","metadata":{"name":"cool-xr"},"spec":{"count":2},"status":{"state":{"foo":"bar","baz":"qux"}}}`),
+						},
+					},
+				},
+			},
+		},
+		"ResponseIsReturnedWithTemplatedXR": {
+			reason: "The Function should return the desired composite resource and the composed templated XR resource.",
+			args: args{
+				req: &fnv1beta1.RunFunctionRequest{
+					Meta: &fnv1beta1.RequestMeta{Tag: "status"},
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: xrRecursiveTmpl},
+						}),
+					Observed: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1beta1.RunFunctionResponse{
+					Meta: &fnv1beta1.ResponseMeta{Tag: "status", Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &fnv1beta1.State{
+						Composite: &fnv1beta1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+						Resources: map[string]*fnv1beta1.Resource{
+							"recursive-xr": {
+								Resource: resource.MustStructJSON(`{"apiVersion": "example.org/v1","kind":"XR","metadata":{"annotations":{},"name":"recursive-xr","labels":{"belongsTo":"cool-xr"}},"spec":{"count":2}}`),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
### Description of your changes

This pull request implements support for creating composed resources with the composite resource's type. The logic is based on the presence of the `gotemplating.fn.crossplane.io/composition-resource-name` meta annotation:

* If not present, only the status field of the composite resource is updated. _(previous functionality)_
* If present, a composed resource with the composite resource's type is created. _(new functionality)_

Fixes #127

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
