### PR TITLE
Add support for getting resources with dots

### DIFF
--- a/function_maps.go
+++ b/function_maps.go
@@ -114,7 +114,7 @@ func initInclude(t *template.Template) func(string, interface{}) (string, error)
 
 func getComposedResource(req map[string]any, name string) map[string]any {
 	var cr map[string]any
-	path := fmt.Sprintf("observed.resources.%s.resource", name)
+	path := fmt.Sprintf("observed.resources[%s]resource", name)
 	if err := fieldpath.Pave(req).GetValueInto(path, &cr); err != nil {
 		return nil
 	}

--- a/function_maps_test.go
+++ b/function_maps_test.go
@@ -375,6 +375,22 @@ func Test_getComposedResource(t *testing.T) {
 			},
 			want: want{rsp: completeResource},
 		},
+		"RetrieveCompleteResourceWithDots": {
+			reason: "Should successfully retrieve the complete resource when identifier contains dots",
+			args: args{
+				req: map[string]any{
+					"observed": map[string]any{
+						"resources": map[string]any{
+							"flex.server": map[string]any{
+								"resource": completeResource,
+							},
+						},
+					},
+				},
+				name: "flex.server",
+			},
+			want: want{rsp: completeResource},
+		},
 		"ResourceNotFound": {
 			reason: "Should return nil if the resource is not found",
 			args: args{


### PR DESCRIPTION
### Description of your changes
Adds support for selecting resources with dots in their name by using angle-brackets syntax instead of path syntax.

Fixes #138 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
