### PR TITLE
feat: Add utility function to retrieve function credentials

### DIFF
--- a/example/functions/getCredentialData/README.md
+++ b/example/functions/getCredentialData/README.md
@@ -3,7 +3,7 @@ The getCredentialData function is a utility function used to facilitate the retr
 
 ## Testing This Function Locally
 
-You can run your function locally and test it with [`crossplane render`](https://docs.crossplane.io/v1.18/cli/command-reference/#render/)
+You can run your function locally and test it with [`crossplane render`](https://docs.crossplane.io/latest/cli/command-reference/#render/)
 
 ```shell {copy-lines="1-3"}
 crossplane render xr.yaml composition.yaml functions.yaml \

--- a/example/functions/getCredentialData/README.md
+++ b/example/functions/getCredentialData/README.md
@@ -1,0 +1,29 @@
+# getCredentialData
+The getCredentialData function is a utility function used to facilitate the retrieval of a function credential. Upon successful retrieval, the function returns the data of the credential. If the credential cannot be located or is unreachable, it returns nil.
+
+## Testing This Function Locally
+
+You can run your function locally and test it with [`crossplane render`](https://docs.crossplane.io/v1.18/cli/command-reference/#render/)
+
+```shell {copy-lines="1-3"}
+crossplane render xr.yaml composition.yaml functions.yaml \
+    --function-credentials=credentials.yaml \
+    --include-context
+---
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T00:00:00Z"
+    reason: Available
+    status: "True"
+    type: Ready
+---
+apiVersion: render.crossplane.io/v1beta1
+fields:
+  password: bar
+  username: foo
+kind: Context
+```

--- a/example/functions/getCredentialData/composition.yaml
+++ b/example/functions/getCredentialData/composition.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-function-get-credential-data
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      credentials:
+        - name: foo-creds
+          secretRef:
+            name: foo-creds
+            namespace: default
+          source: Secret
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: Context
+            data:
+              username: {{ ( getCredentialData . "foo-creds" ).username | toString }}
+              password: {{ ( getCredentialData . "foo-creds" ).password | toString }}

--- a/example/functions/getCredentialData/credentials.yaml
+++ b/example/functions/getCredentialData/credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo-creds
+  namespace: default
+type: Opaque
+data:
+  username: Zm9v # foo
+  password: YmFy # bar

--- a/example/functions/getCredentialData/functions.yaml
+++ b/example/functions/getCredentialData/functions.yaml
@@ -1,0 +1,8 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+  annotations:
+    render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.8.0

--- a/example/functions/getCredentialData/functions.yaml
+++ b/example/functions/getCredentialData/functions.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.810.0
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.10.0

--- a/example/functions/getCredentialData/functions.yaml
+++ b/example/functions/getCredentialData/functions.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.8.0
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.810.0

--- a/example/functions/getCredentialData/xr.yaml
+++ b/example/functions/getCredentialData/xr.yaml
@@ -1,0 +1,5 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec: {}

--- a/function_maps.go
+++ b/function_maps.go
@@ -154,15 +154,12 @@ func getCredentialData(mReq map[string]any, credName string) map[string][]byte {
 		return nil
 	}
 
-	var data map[string][]byte
 	switch req.GetCredentials()[credName].GetSource().(type) {
 	case *fnv1.Credentials_CredentialData:
-		data = req.GetCredentials()[credName].GetCredentialData().GetData()
+		return req.GetCredentials()[credName].GetCredentialData().GetData()
 	default:
 		return nil
 	}
-
-	return data
 }
 
 func convertFromMap(mReq map[string]any) (*fnv1.RunFunctionRequest, error) {


### PR DESCRIPTION
### Description of your changes

This PR creates a new utility function getCredentialData facilitating the retrieval of function credentials so they can be used when composing Crossplane Resources in Go Templates. 

Fixes #74 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
