### PR TITLE
Update Go version and enable pushing to ghcr.io in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.3'
+  GO_VERSION: '1.23.6'
   GOLANGCI_VERSION: 'v1.62.0'
   DOCKER_BUILDX_VERSION: 'v0.11.2'
 
@@ -31,6 +31,7 @@ env:
   # The package to push, without a version tag. The default matches GitHub. For
   # example xpkg.upbound.io/crossplane/function-template-go.
   XPKG: xpkg.upbound.io/${{ github.repository}}
+  CROSSPLANE_REGORG: ghcr.io/${{ github.repository}} # xpkg.crossplane.io/crossplane-contrib
 
   # The package version to push. The default is 0.0.0-gitsha.
   XPKG_VERSION: ${{ inputs.version }}
@@ -165,3 +166,14 @@ jobs:
       - name: Push Multi-Platform Package to Upbound
         if: env.XPKG_ACCESS_ID != ''
         run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${{ env.XPKG }}:${{ env.XPKG_VERSION }}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Multi-Platform Package to GHCR
+        if: env.XPKG_ACCESS_ID != ''
+        run: "./crossplane --verbose xpkg push --package-files $(echo *.xpkg|tr ' ' ,) ${{ env.CROSSPLANE_REGORG }}:${{ env.XPKG_VERSION }}"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crossplane-contrib/function-go-templating
 
-go 1.23
-
-toolchain go1.23.3
+go 1.23.6
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
### Description of your changes

This PR updates go version to fix the following CVEs and enable pushing to ghcr.io in CI.
```
NAME    INSTALLED  FIXED-IN    TYPE       VULNERABILITY   SEVERITY
stdlib  go1.23.3   1.23.6      go-module  CVE-2025-22866  Medium
stdlib  go1.23.3   1.23.5      go-module  CVE-2024-45341  Medium
stdlib  go1.23.3   1.23.5      go-module  CVE-2024-45336  Medium
```

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
