### PR TITLE
feat: add helper method to retreive extra resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ conditions:
 | [`getResourceCondition`](example/functions/getResourceCondition) | Helper function to retreive conditions of resources          |
 | [`getComposedResource`](example/functions/getComposedResource)    | Helper function to retrieve observed composed resources      |
 | [`getCompositeResource`](example/functions/getCompositeResource) | Helper function to retreive the observed composite resource |
+| [`getExtraResources`](example/functions/getExtraResources)       | Helper function to retreive extra resources                  |
 | [`setResourceNameAnnotation`](example/inline)                    | Returns the special resource-name annotation with given name |
 | [`include`](example/functions/include)                           | Outputs template as a string                                 |
 

--- a/example/functions/getExtraResources/composition.yaml
+++ b/example/functions/getExtraResources/composition.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-extra-resources
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              bucket:
+                apiVersion: s3.aws.upbound.io/v1beta1
+                kind: Bucket
+                matchName: my-awesome-{{ .observed.composite.resource.spec.environment }}-bucket
+            {{ $someExtraResources := getExtraResources . "bucket" }}
+            {{- range $i, $extraResource := default (list) $someExtraResources }}
+            ---
+            apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            metadata:
+              annotations: 
+                gotemplating.fn.crossplane.io/composition-resource-name: bucket-configmap-{{ $i }}
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Configmap
+                  metadata:
+                    name: {{ $extraResource.resource.metadata.name }}-bucket
+                  data:
+                    bucket: {{ $extraResource.resource.status.atProvider.id }} 
+              providerConfigRef:
+                name: "kubernetes"
+            {{- end }}
+            ---
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            status:
+              dummy: cool-status

--- a/example/functions/getExtraResources/extraResources.yaml
+++ b/example/functions/getExtraResources/extraResources.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  labels:
+    testing.upbound.io/example-name: bucket-notification
+  name: my-awesome-dev-bucket
+spec:
+  forProvider:
+    region: us-west-1
+status:
+  atProvider:
+    id: random-bucket-id

--- a/example/functions/getExtraResources/functions.yaml
+++ b/example/functions/getExtraResources/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.9.0

--- a/example/functions/getExtraResources/xr.yaml
+++ b/example/functions/getExtraResources/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  environment: dev

--- a/function_maps.go
+++ b/function_maps.go
@@ -26,6 +26,7 @@ var funcMaps = []template.FuncMap{
 		"setResourceNameAnnotation": setResourceNameAnnotation,
 		"getComposedResource":       getComposedResource,
 		"getCompositeResource":      getCompositeResource,
+		"getExtraResources":         getExtraResources,
 	},
 }
 
@@ -129,4 +130,14 @@ func getCompositeResource(req map[string]any) map[string]any {
 	}
 
 	return cr
+}
+
+func getExtraResources(req map[string]any, name string) []any {
+	var ers []any
+	path := fmt.Sprintf("extraResources[%s]items", name)
+	if err := fieldpath.Pave(req).GetValueInto(path, &ers); err != nil {
+		return nil
+	}
+
+	return ers
 }


### PR DESCRIPTION
### Description of your changes

This PR adds a simple helper function to retrieve an extra resource from the request.
Previously one had to write something like this in the template to retrieve a single resource:
```golang
{{- $bucket := mustFirst (index (index .extraResources "bucket") "items") }}
```
With the helper function it simplifies to:
```golang
{{- $bucket := mustFirst (getExtraResources "bucket") }}
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
