### PR TITLE
Add fromJson/toJson functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ conditions:
 | [`randomChoice`](example/inline)                                 | Randomly selects one of a given strings                      |
 | [`toYaml`](example/functions/toYaml)                             | Marshals any object into a YAML string                       |
 | [`fromYaml`](example/functions/fromYaml)                         | Unmarshals a YAML string into an object                      |
+| [`toJson`](example/functions/toJson)                             | Marshals any object/array into a JSON string                 |
+| [`fromJson`](example/functions/fromJson)                         | Unmarshals a JSON string into an object/array                |
 | [`getResourceCondition`](example/functions/getResourceCondition) | Helper function to retreive conditions of resources          |
 | [`getComposedResource`](example/functions/getComposedResource)    | Helper function to retrieve observed composed resources      |
 | [`getCompositeResource`](example/functions/getCompositeResource) | Helper function to retreive the observed composite resource |

--- a/example/functions/fromJson/composition.yaml
+++ b/example/functions/fromJson/composition.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-function-from-json
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: {{ .observed.composite.resource.apiVersion }}
+            kind: {{ .observed.composite.resource.kind }}
+            status:
+              # Extract single value from encoded json string
+              dummy: {{ (.observed.composite.resource.spec.jsonObject | fromJson).key2 }}
+              foo: {{ index (.observed.composite.resource.spec.jsonArray | fromJson) 0 }}

--- a/example/functions/fromJson/functions.yaml
+++ b/example/functions/fromJson/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.10.0

--- a/example/functions/fromJson/xr.yaml
+++ b/example/functions/fromJson/xr.yaml
@@ -1,0 +1,9 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  jsonObject: |
+    {"key1":"value1","key2":"value2","key3":"value3"}
+  jsonArray: |
+    ["foo","baz"]

--- a/example/functions/toJson/composition.yaml
+++ b/example/functions/toJson/composition.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-function-to-json
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: {{ .observed.composite.resource.apiVersion }}
+            kind: {{ .observed.composite.resource.kind }}
+            status:
+              # Marshall whole 'complexDictionary' as json string
+              dummy: {{ .observed.composite.resource.spec.complexDictionary | toJson | quote }}

--- a/example/functions/toJson/functions.yaml
+++ b/example/functions/toJson/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.10.0

--- a/example/functions/toJson/xr.yaml
+++ b/example/functions/toJson/xr.yaml
@@ -1,0 +1,12 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  complexDictionary:
+    scalar1: true
+    scalar2: text
+    scalar3: 123
+    list:
+      - abc
+      - def

--- a/function_maps.go
+++ b/function_maps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -22,6 +23,8 @@ var funcMaps = []template.FuncMap{
 		"randomChoice":              randomChoice,
 		"toYaml":                    toYaml,
 		"fromYaml":                  fromYaml,
+		"toJson":                    toJSON,
+		"fromJson":                  fromJSON,
 		"getResourceCondition":      getResourceCondition,
 		"setResourceNameAnnotation": setResourceNameAnnotation,
 		"getComposedResource":       getComposedResource,
@@ -75,6 +78,24 @@ func fromYaml(val string) (any, error) {
 	err := yaml.Unmarshal([]byte(val), &res)
 
 	return res, err
+}
+
+func toJSON(v interface{}) (string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func fromJSON(str string) (any, error) {
+	var res any
+	if err := json.Unmarshal([]byte(str), &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 func getResourceCondition(ct string, res map[string]any) xpv1.Condition {

--- a/function_maps_test.go
+++ b/function_maps_test.go
@@ -126,6 +126,126 @@ func Test_toYaml(t *testing.T) {
 	}
 }
 
+func Test_fromJson(t *testing.T) {
+	type args struct {
+		val string
+	}
+	type want struct {
+		rsp any
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"UnmarshalJsonObject": {
+			reason: "Should return unmarshalled json",
+			args: args{
+				val: `{"complexDictionary": {"scalar1": true, "list": ["abc", "def"]}}`,
+			},
+			want: want{
+				rsp: map[string]interface{}{
+					"complexDictionary": map[string]interface{}{
+						"scalar1": true,
+						"list": []interface{}{
+							"abc",
+							"def",
+						},
+					},
+				},
+			},
+		},
+		"UnmarshalJsonArray": {
+			reason: "Should return unmarshalled json array",
+			args: args{
+				val: `[{"complexDictionary": {"scalar1": true, "list": ["abc", "def"]}}]`,
+			},
+			want: want{
+				rsp: []interface{}{
+					map[string]interface{}{
+						"complexDictionary": map[string]interface{}{
+							"scalar1": true,
+							"list": []interface{}{
+								"abc",
+								"def",
+							},
+						},
+					},
+				},
+			},
+		},
+		"UnmarshalJsonError": {
+			reason: "Should return error when unmarshalling json",
+			args: args{
+				val: `{a}`,
+			},
+			want: want{
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := fromJSON(tc.args.val)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nfromJson(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nfromJson(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func Test_toJson(t *testing.T) {
+	type args struct {
+		val any
+	}
+	type want struct {
+		rsp any
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"MarshalJson": {
+			reason: "Should return marshalled json",
+			args: args{
+				val: map[string]interface{}{
+					"complexDictionary": map[string]interface{}{
+						"scalar1": true,
+						"list": []interface{}{
+							"abc",
+							"def",
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: `{"complexDictionary":{"list":["abc","def"],"scalar1":true}}`,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := toJSON(tc.args.val)
+
+			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\ntoJson(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\ntoJson(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func Test_getResourceCondition(t *testing.T) {
 	type args struct {
 		ct  string


### PR DESCRIPTION
### Description of your changes

Similarly to fromYaml/toYaml added functions for dealing with JSON. We are lacking this functionality when working with `provider-terraform` as it supports only primitive types in outputs forcing us to encode complex objects/arrays into strings. Terraform has built-in json marshalling functions and being able to parse it in template back into the object would help us avoid writing our own encoding/decoding patterns with nested `split`s.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
