### PR TITLE
Test larger gRPC message size

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,17 +7,15 @@ import (
 	"github.com/crossplane/function-sdk-go"
 )
 
-// MaxRecvMessageSize sets the maximum message size. gRPC default is 4MB
-const MaxRecvMessageSize = 1024 * 1024 * 16
-
 // CLI of this Function.
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
 
-	Network     string `help:"Network on which to listen for gRPC connections." default:"tcp"`
-	Address     string `help:"Address at which to listen for gRPC connections." default:":9443"`
-	TLSCertsDir string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
-	Insecure    bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	Network            string `help:"Network on which to listen for gRPC connections." default:"tcp"`
+	Address            string `help:"Address at which to listen for gRPC connections." default:":9443"`
+	TLSCertsDir        string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
+	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
+	MaxRecvMessageSize int    `help:"gRPC maximum message size in bytes. Increase this when processing large Composites." default:"4194304"`
 }
 
 // Run this Function.
@@ -35,8 +33,7 @@ func (c *CLI) Run() error {
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure),
-		function.MaxRecvMessageSize(MaxRecvMessageSize),
-	)
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ type CLI struct {
 	Address            string `help:"Address at which to listen for gRPC connections." default:":9443"`
 	TLSCertsDir        string `help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)" env:"TLS_SERVER_CERTS_DIR"`
 	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
-	MaxRecvMessageSize int    `help:"gRPC maximum message size in bytes. Increase this when processing large Composites." default:"4194304"`
+	MaxRecvMessageSize int    `help:"Maximum size of received messages in MB." default:"4"`
 }
 
 // Run this Function.
@@ -33,7 +33,7 @@ func (c *CLI) Run() error {
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure),
-		function.MaxRecvMessageSize(c.MaxRecvMessageSize))
+		function.MaxRecvMessageSize(c.MaxRecvMessageSize*1024*1024))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,9 @@ import (
 	"github.com/crossplane/function-sdk-go"
 )
 
+// MaxRecvMessageSize sets the maximum message size. gRPC default is 4MB
+const MaxRecvMessageSize = 1024 * 1024 * 16
+
 // CLI of this Function.
 type CLI struct {
 	Debug bool `short:"d" help:"Emit debug logs in addition to info logs."`
@@ -31,7 +34,9 @@ func (c *CLI) Run() error {
 		},
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
-		function.Insecure(c.Insecure))
+		function.Insecure(c.Insecure),
+		function.MaxRecvMessageSize(MaxRecvMessageSize),
+	)
 }
 
 func main() {


### PR DESCRIPTION
### Description of your changes

Adds a cli option, `--max-recv-message-size` to allow users to set the gRPC max message size. 

Fixes # https://github.com/crossplane/crossplane/issues/6392

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
