### PR TITLE
Allow a default source path to be specified via envvar

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -15,18 +15,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-
 	"github.com/crossplane/function-sdk-go/errors"
 	"github.com/crossplane/function-sdk-go/logging"
 	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
-
-	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 )
+
+var defaultSource = os.Getenv("FUNCTION_GO_TEMPLATING_DEFAULT_SOURCE")
 
 // osFS is a dead-simple implementation of [io/fs.FS] that just wraps around
 // [os.Open].
@@ -61,6 +61,12 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	if err := request.GetInput(req, in); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot get Function input from %T", req))
 		return rsp, nil
+	}
+	if in.Source == "" && defaultSource != "" {
+		in.Source = v1beta1.FileSystemSource
+		in.FileSystem = &v1beta1.TemplateSourceFileSystem{
+			DirPath: defaultSource,
+		}
 	}
 
 	tg, err := NewTemplateSourceGetter(f.fsys, in)

--- a/fn_test.go
+++ b/fn_test.go
@@ -12,13 +12,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/utils/ptr"
 
+	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
-
-	"github.com/crossplane-contrib/function-go-templating/input/v1beta1"
 )
 
 var (
@@ -59,8 +57,9 @@ var (
 
 func TestRunFunction(t *testing.T) {
 	type args struct {
-		ctx context.Context
-		req *fnv1.RunFunctionRequest
+		ctx           context.Context
+		req           *fnv1.RunFunctionRequest
+		defaultSource string
 	}
 	type want struct {
 		rsp *fnv1.RunFunctionResponse
@@ -152,6 +151,28 @@ func TestRunFunction(t *testing.T) {
 						{
 							Severity: fnv1.Severity_SEVERITY_FATAL,
 							Message:  "invalid function input: fileSystem.dirPath should be provided",
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+						},
+					},
+				},
+			},
+		},
+		"DefaultSourceDoesNotExist": {
+			// We can't easily inject a filesystem with valid input into the
+			// test, so just make sure the default source is used and assume it
+			// would work properly if it pointed to something valid.
+			reason: "The default source should be used if specified when the input is empty",
+			args: args{
+				req:           &fnv1.RunFunctionRequest{},
+				defaultSource: "does/not/exist",
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{
+						{
+							Severity: fnv1.Severity_SEVERITY_FATAL,
+							Message:  "invalid function input: cannot read tmpl from the folder {does/not/exist}: open does/not/exist: file does not exist",
 							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},
@@ -952,6 +973,9 @@ func TestRunFunction(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			// NOTE: This means we can't run tests in parallel.
+			defaultSource = tc.args.defaultSource
+
 			f := &Function{
 				log:  logging.NewNopLogger(),
 				fsys: testdataFS,

--- a/package/input/gotemplating.fn.crossplane.io_gotemplates.yaml
+++ b/package/input/gotemplating.fn.crossplane.io_gotemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: gotemplates.gotemplating.fn.crossplane.io
 spec:
   group: gotemplating.fn.crossplane.io
@@ -22,9 +22,11 @@ spec:
         description: A GoTemplate is used to provide templates to this Function.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           delims:
             description: Template delimiters
@@ -51,9 +53,12 @@ spec:
                 type: string
             type: object
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object


### PR DESCRIPTION
### Description of your changes

Enable function-go-templating to be used as a base image for custom functions with go templates included in the image by allowing the function input to be empty when a default source is set via environment variable. A user can build a custom function on top of function-go-templating by adding a directory containing go templates to the image and setting the environment variable `FUNCTION_GO_TEMPLATING_DEFAULT_SOURCE` to the template directory's path. The behavior of the function will be the same as if the templates were mounted into the function pod and the `Filesystem` input source used.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
