### PR TITLE
Allow using getResourceCondition directly on observed resources

### DIFF
--- a/function_maps.go
+++ b/function_maps.go
@@ -80,7 +80,9 @@ func fromYaml(val string) (any, error) {
 func getResourceCondition(ct string, res map[string]any) xpv1.Condition {
 	var conditioned xpv1.ConditionedStatus
 	if err := fieldpath.Pave(res).GetValueInto("resource.status", &conditioned); err != nil {
-		conditioned = xpv1.ConditionedStatus{}
+		if err := fieldpath.Pave(res).GetValueInto("status", &conditioned); err != nil {
+			conditioned = xpv1.ConditionedStatus{}
+		}
 	}
 
 	// Return either found condition or empty one with "Unknown" status

--- a/function_maps_test.go
+++ b/function_maps_test.go
@@ -32,7 +32,7 @@ func Test_fromYaml(t *testing.T) {
 complexDictionary:
   scalar1: true
   list:
-  - abc	
+  - abc
   - def`,
 			},
 			want: want{
@@ -152,6 +152,28 @@ func Test_getResourceCondition(t *testing.T) {
 									"type":   "Ready",
 									"status": "True",
 								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: v1.Condition{
+					Type:   "Ready",
+					Status: "True",
+				},
+			},
+		},
+		"GetConditionObservedResource": {
+			reason: "Should return condition, even if not wrapped in 'resource'",
+			args: args{
+				ct: "Ready",
+				res: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
+								"type":   "Ready",
+								"status": "True",
 							},
 						},
 					},


### PR DESCRIPTION


### Description of your changes
Added a check for retrieving a resource condition on resources not wrapped in a `resource` object as was previously expected from the function

Fixes #462  

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
