### PR TITLE
Write extra resources into context

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ example:
 {{- end }}
 ```
 
+Additionally, the function will store retreived extraResources in the function
+context under the `apiextensions.crossplane.io/extra-resources` key, so that
+extra resources are passed down the pipeline.
+```json5
+{
+  "context": {
+    "apiextensions.crossplane.io/extra-resources": {
+      "some-foo-by-name": [
+        // ... the requested bucket if found, empty otherwise ...
+      ],
+      "some-foo-by-labels": [
+        // ... the requested buckets if found, empty otherwise ...
+      ],
+      // ... any other requested extra resources ...
+    }
+  }
+  
+}
+```
+If a function previously set extra resources under the key in the context,
+the function will merge the new extra resources in, so both can be obtained
+in the next pipeline step.
+
 ### Writing to the Context
 
 This function can write to the Composition [Context](https://docs.crossplane.io/latest/concepts/compositions/#function-pipeline-context). Subsequent pipeline steps will be able to access the data.
@@ -326,19 +349,24 @@ conditions:
   target: CompositeAndClaim
 ```
 
-## Additional functions
+## Additional Functions
 
-| Name                                                             | Description                                                  |
-|------------------------------------------------------------------|--------------------------------------------------------------|
-| [`randomChoice`](example/inline)                                 | Randomly selects one of a given strings                      |
-| [`toYaml`](example/functions/toYaml)                             | Marshals any object into a YAML string                       |
-| [`fromYaml`](example/functions/fromYaml)                         | Unmarshals a YAML string into an object                      |
-| [`getResourceCondition`](example/functions/getResourceCondition) | Helper function to retrieve conditions of resources          |
-| [`getComposedResource`](example/functions/getComposedResource)    | Helper function to retrieve observed composed resources      |
-| [`getCompositeResource`](example/functions/getCompositeResource) | Helper function to retrieve the observed composite resource |
-| [`getExtraResources`](example/functions/getExtraResources)       | Helper function to retrieve extra resources                  |
-| [`setResourceNameAnnotation`](example/inline)                    | Returns the special resource-name annotation with given name |
-| [`include`](example/functions/include)                           | Outputs template as a string                                 |
+The following custom template functions are available in addition to Go's built-in and Sprig functions:
+
+| Name                                                                  | Description                                                                 |
+|-----------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| [`randomChoice`](example/inline)                                      | Randomly selects one of a given set of strings.                             |
+| [`toYaml`](example/functions/toYaml)                                  | Marshals any object into a YAML string.                                     |
+| [`fromYaml`](example/functions/fromYaml)                              | Unmarshals a YAML string into an object.                                    |
+| [`getResourceCondition`](example/functions/getResourceCondition)      | Retrieves conditions of resources.                                          |
+| [`getComposedResource`](example/functions/getComposedResource)        | Retrieves observed composed resources.                                      |
+| [`getCompositeResource`](example/functions/getCompositeResource)      | Retrieves the observed composite resource.                                  |
+| [`getExtraResources`](example/functions/getExtraResources)            | Retrieves extra resources.                                                  |
+| [`getExtraResourcesFromContext`](example/functions/getExtraResourcesFromContext) | Retrieves extra resources from the environment context.                     |
+| [`setResourceNameAnnotation`](example/inline)                         | Returns the special resource-name annotation with the given name.            |
+| [`include`](example/functions/include)                                | Outputs a template as a string.                                             |
+
+See the linked examples for usage details.
 
 ## Developing this function
 

--- a/example/functions/getExtraResourcesFromContext/composition.yaml
+++ b/example/functions/getExtraResourcesFromContext/composition.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-extra-resources
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: extra-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              bucket:
+                apiVersion: s3.aws.upbound.io/v1beta1
+                kind: Bucket
+                matchName: my-awesome-{{ .observed.composite.resource.spec.environment }}-bucket  
+
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{ $someExtraResources := getExtraResourcesFromContext . "bucket" }}
+            {{- range $i, $extraResource := default (list) $someExtraResources }}
+            ---
+            apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            metadata:
+              annotations: 
+                gotemplating.fn.crossplane.io/composition-resource-name: bucket-configmap-{{ $i }}
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Configmap
+                  metadata:
+                    name: {{ $extraResource.resource.metadata.name }}-bucket
+                  data:
+                    bucket: {{ $extraResource.resource.status.atProvider.id }} 
+              providerConfigRef:
+                name: "kubernetes"
+            {{- end }}
+            ---
+            apiVersion: example.crossplane.io/v1beta1
+            kind: XR
+            status:
+              dummy: cool-status

--- a/example/functions/getExtraResourcesFromContext/extraResources.yaml
+++ b/example/functions/getExtraResourcesFromContext/extraResources.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  labels:
+    testing.upbound.io/example-name: bucket-notification
+  name: my-awesome-dev-bucket
+spec:
+  forProvider:
+    region: us-west-1
+status:
+  atProvider:
+    id: random-bucket-id

--- a/example/functions/getExtraResourcesFromContext/functions.yaml
+++ b/example/functions/getExtraResourcesFromContext/functions.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.11.0

--- a/example/functions/getExtraResourcesFromContext/xr.yaml
+++ b/example/functions/getExtraResourcesFromContext/xr.yaml
@@ -1,0 +1,6 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec:
+  environment: dev

--- a/fn.go
+++ b/fn.go
@@ -331,6 +331,13 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		rsp.Requirements = requirements
 	}
 
+	if len(req.ExtraResources) > 0 {
+		err = mergeExtraResourcesToContext(req, rsp)
+		if err != nil {
+			return rsp, nil
+		}
+	}
+
 	f.log.Debug("Successfully composed desired resources", "source", in.Source, "count", len(objs))
 
 	return rsp, nil

--- a/function_maps.go
+++ b/function_maps.go
@@ -22,15 +22,16 @@ const recursionMaxNums = 1000
 
 var funcMaps = []template.FuncMap{
 	{
-		"randomChoice":              randomChoice,
-		"toYaml":                    toYaml,
-		"fromYaml":                  fromYaml,
-		"getResourceCondition":      getResourceCondition,
-		"setResourceNameAnnotation": setResourceNameAnnotation,
-		"getComposedResource":       getComposedResource,
-		"getCompositeResource":      getCompositeResource,
-		"getExtraResources":         getExtraResources,
-		"getCredentialData":         getCredentialData,
+		"randomChoice":                 randomChoice,
+		"toYaml":                       toYaml,
+		"fromYaml":                     fromYaml,
+		"getResourceCondition":         getResourceCondition,
+		"setResourceNameAnnotation":    setResourceNameAnnotation,
+		"getComposedResource":          getComposedResource,
+		"getCompositeResource":         getCompositeResource,
+		"getExtraResources":            getExtraResources,
+		"getExtraResourcesFromContext": getExtraResourcesFromContext,
+		"getCredentialData":            getCredentialData,
 	},
 }
 
@@ -141,6 +142,16 @@ func getCompositeResource(req map[string]any) map[string]any {
 func getExtraResources(req map[string]any, name string) []any {
 	var ers []any
 	path := fmt.Sprintf("extraResources[%s].items", name)
+	if err := fieldpath.Pave(req).GetValueInto(path, &ers); err != nil {
+		return nil
+	}
+
+	return ers
+}
+
+func getExtraResourcesFromContext(req map[string]any, name string) []any {
+	var ers []any
+	path := fmt.Sprintf("context[%s][%s].items", extraResourcesContextKey, name)
 	if err := fieldpath.Pave(req).GetValueInto(path, &ers); err != nil {
 		return nil
 	}


### PR DESCRIPTION
### Description of your changes

This PR introduces a change where extra resources obtained by the function are written into the function context, so they can be used by the following functions in the pipeline.
It is highly inspired by the approach [function-extra-resources](https://github.com/crossplane-contrib/function-extra-resources) took.
We also introduce a new helper function `getExtraResourcesFromContext` to obtain an extra resources from the function context. It is more explicit than extending the existing `getExtraResources` function which might lead to intransparent behaviour.

Previously to this change, one had to write some templating like so:
```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: example-extra-resources
spec:
  compositeTypeRef:
    apiVersion: example.crossplane.io/v1beta1
    kind: XR
  mode: Pipeline
  pipeline:
    - step: extra-resources
      functionRef:
        name: function-go-templating
      input:
        apiVersion: gotemplating.fn.crossplane.io/v1beta1
        kind: GoTemplate
        source: Inline
        inline:
          template: |
            ---
            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
            kind: ExtraResources
            requirements:
              bucket:
                apiVersion: s3.aws.upbound.io/v1beta1
                kind: Bucket
                matchName: my-awesome-{{ .observed.composite.resource.spec.environment }}-bucket  
            {{- if .extraResources }}
            ---
            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
            kind: Context
            data:
              "apiextensions.crossplane.io/extra-resources":
                {{- .extraResources | toYaml | nindent 4 }}
            {{- end }}

    - step: render-templates
      functionRef:
        name: function-go-templating
      input:
        apiVersion: gotemplating.fn.crossplane.io/v1beta1
        kind: GoTemplate
        source: Inline
        inline:
          template: |
            {{ $someExtraResources := (index (index (index .context "apiextensions.crossplane.io/extra-resources") "bucket") "items" }}
           # ....
```

I am very confident that this change makes the lives of the developers easier and enables the function pipeline to be easier usable. The only thing I'm unsure about is whether that should be default behavior or rather opt-in on the function level.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
