### PR TITLE
Add error context to YAML errors for better debugging

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -139,7 +139,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 					context = context[:80] + "..."
 				}
 
-				newErr = fmt.Errorf("error converting YAML to JSON: yaml: line %d (document %d, line %d) near: %s: %s", yamlErr.AbsLine, docIndex+1, yamlErr.RelLine, context, yamlErr.Message)
+				newErr = fmt.Errorf("error converting YAML to JSON: yaml: line %d (document %d, line %d) near: '%s': %s", yamlErr.AbsLine, docIndex+1, yamlErr.RelLine, context, yamlErr.Message)
 			}
 
 			response.Fatal(rsp, errors.Wrap(newErr, "cannot decode manifest"))

--- a/fn_test.go
+++ b/fn_test.go
@@ -1226,7 +1226,7 @@ func TestRunFunction(t *testing.T) {
 					Results: []*fnv1.Result{
 						{
 							Severity: fnv1.Severity_SEVERITY_FATAL,
-							Message:  "cannot decode manifest: error converting YAML to JSON: yaml: line 6 (document 1, line 4) near: name: %!@#$%^&*()_+: found character that cannot start any token",
+							Message:  "cannot decode manifest: error converting YAML to JSON: yaml: line 6 (document 1, line 4) near: 'name: %!@#$%^&*()_+': found character that cannot start any token",
 							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},


### PR DESCRIPTION
### Description of your changes

This PR adds additional error context to YAML syntax errors. When using the function with go-templating it is very common to run into issues as no one gets the templates right on the first try. In case of YAML errors the function would just indicate the error line local to the document its currently processing.
Assume we have a composition like so:
```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: complex-composition
spec:
  mode: Pipeline
  compositeTypeRef:
    apiVersion: example.crossplane.io/v1beta1
    kind: XR
  pipeline:
    - step: render-templates
      functionRef:
        name: function-go-templating
      input:
        apiVersion: gotemplating.fn.crossplane.io/v1beta1
        kind: GoTemplate
        source: Inline
        inline:
          template: |
            ---
            apiVersion: s3.aws.upbound.io/v1beta1
            kind: Bucket
            metadata:
              annotations:
                gotemplating.fn.crossplane.io/composition-resource-name: bucket-1
            spec:
              forProvider:
                region: {{ printf "%s" .observed.composite.resource.spec.region }}
            ---
            apiVersion: s3.aws.upbound.io/v1beta1
            kind: Bucket
            metadata:
              annotations:
                gotemplating.fn.crossplane.io/composition-resource-name: bucket-2
            spec:
              forProvider:
                region: {{ printf "%s"  .observed.composite.resource.spec.region }}
            ---
            apiVersion: s3.aws.upbound.io/v1beta1
            kind: Bucket
            metadata:
              annotations:
                gotemplating.fn.crossplane.io/composition-resource-name: bucket-2
            spec:
              forProvider:
                region: {{ printf "%s"  .obsevred.composite.resource.spec.region }}
```
When we apply this function, the error would simply say `error converting YAML to JSON: yaml: line 8: found character that cannot start any token`. Can you spot the error with that much information easily? Probably not.
With this change, we get more clues into the error message, turning into `error converting YAML to JSON: yaml: line 27 (document 3, line 8) near: 'region: %!(nil)': found character that cannot start any token`.
With that information we can pinpoint the issue with the following information:
- Line 27 in the template
- Document 3 in the template
- Line 8 in the document
- near `region: %!(nil)`
And with a close look into that particular line, we see that `obsevred` has a typo.

I'm very confident that this brings a lot of value to composition authors using this function. However, I'm open for discussions and improvements.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
