### PR TITLE
Add getComposedConnectionDetails template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ The following custom template functions are available in addition to Go's built-
 | [`fromYaml`](example/functions/fromYaml)                              | Unmarshals a YAML string into an object.                                    |
 | [`getResourceCondition`](example/functions/getResourceCondition)      | Retrieves conditions of resources.                                          |
 | [`getComposedResource`](example/functions/getComposedResource)        | Retrieves observed composed resources.                                      |
+| [`getComposedConnectionDetails`](example/functions/getComposedConnectionDetails) | Retrieves connection details of an observed composed resource.       |
 | [`getCompositeResource`](example/functions/getCompositeResource)      | Retrieves the observed composite resource.                                  |
 | [`getExtraResources`](example/functions/getExtraResources)            | Retrieves extra resources.                                                  |
 | [`getExtraResourcesFromContext`](example/functions/getExtraResourcesFromContext) | Retrieves extra resources from the environment context.                     |

--- a/example/functions/getComposedConnectionDetails/README.md
+++ b/example/functions/getComposedConnectionDetails/README.md
@@ -1,16 +1,18 @@
 # getComposedConnectionDetails
 The getComposedConnectionDetails function is a utility function used to facilitate the retrieval of connection details for a named observed composed resource. By accepting a function request map and a resource name, it navigates the request structure to fetch the specified composed resource's connection details. If the resource is found, it returns a map containing the connection details; if not, it returns nil, indicating the resource does not exist or its connection details are inaccessible.
 
-## Usage
-
 > **Note:** Connection details are populated by the provider and are only present in real observed state. They cannot be simulated with `crossplane render`.
+
+## Usage
 
 Examples:
 
 ```golang
-// Retrieve the connection details of the observed resource named "flexServer"
-{{ $flexServerCD := getComposedConnectionDetails . "flexServer" }}
+// Retrieve the connection details for observed resources named "accesskey-0" and "accesskey-1"
+{{ $accesskey0 := getComposedConnectionDetails . "accesskey-0" }}
+{{ $accesskey1 := getComposedConnectionDetails . "accesskey-1" }}
 
-// Extract a value from the connection details
-{{ $host := index $flexServerCD "host" }}
+// Extract values from the connection details
+{{ index $accesskey0 "username" }}
+{{ index $accesskey1 "password" }}
 ```

--- a/example/functions/getComposedConnectionDetails/README.md
+++ b/example/functions/getComposedConnectionDetails/README.md
@@ -1,7 +1,7 @@
 # getComposedConnectionDetails
 The getComposedConnectionDetails function is a utility function used to facilitate the retrieval of connection details for a named observed composed resource. By accepting a function request map and a resource name, it navigates the request structure to fetch the specified composed resource's connection details. If the resource is found, it returns a map containing the connection details; if not, it returns nil, indicating the resource does not exist or its connection details are inaccessible.
 
-> **Note:** Connection details are populated by the provider and are only present in real observed state. They cannot be simulated with `crossplane render`.
+> **Note:** Connection details are populated by the provider and are only present in real observed state. They cannot be simulated with `crossplane render`. See [crossplane/crossplane#4808](https://github.com/crossplane/crossplane/issues/4808) for related upstream work.
 
 ## Usage
 

--- a/example/functions/getComposedConnectionDetails/README.md
+++ b/example/functions/getComposedConnectionDetails/README.md
@@ -1,0 +1,16 @@
+# getComposedConnectionDetails
+The getComposedConnectionDetails function is a utility function used to facilitate the retrieval of connection details for a named observed composed resource. By accepting a function request map and a resource name, it navigates the request structure to fetch the specified composed resource's connection details. If the resource is found, it returns a map containing the connection details; if not, it returns nil, indicating the resource does not exist or its connection details are inaccessible.
+
+## Usage
+
+> **Note:** Connection details are populated by the provider and are only present in real observed state. They cannot be simulated with `crossplane render`.
+
+Examples:
+
+```golang
+// Retrieve the connection details of the observed resource named "flexServer"
+{{ $flexServerCD := getComposedConnectionDetails . "flexServer" }}
+
+// Extract a value from the connection details
+{{ $host := index $flexServerCD "host" }}
+```

--- a/example/functions/getComposedConnectionDetails/composition.yaml
+++ b/example/functions/getComposedConnectionDetails/composition.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-function-get-composed-connection-details
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1beta1
+    kind: XR
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            ---
+            {{ $flexServerResourceName := "flexServer" }}
+            # Create an initial composed resource whose connection details we will retrieve
+            apiVersion: dbforpostgresql.azure.upbound.io/v1beta1
+            kind: FlexibleServer
+            metadata:
+              annotations:
+                {{ setResourceNameAnnotation $flexServerResourceName }}
+                gotemplating.fn.crossplane.io/ready: "False"
+            spec:
+              forProvider:
+                storageMb: 32768
+              providerConfigRef:
+                name: my-provider-cfg
+            ---
+            # Use getComposedConnectionDetails to retrieve the connection details of "flexServer"
+            {{ $flexServerCD := getComposedConnectionDetails . $flexServerResourceName }}
+
+            apiVersion: dbforpostgresql.azure.upbound.io/v1beta1
+            kind: FlexibleServerConfiguration
+            metadata:
+              annotations:
+                {{ setResourceNameAnnotation "flexServerConfig" }}
+                gotemplating.fn.crossplane.io/ready: "False"
+            spec:
+              forProvider:
+                # Populate the field using the connection details of the retrieved resource
+                serverHost: {{ index $flexServerCD "host" }}
+              providerConfigRef:
+                name: my-provider-cfg

--- a/example/functions/getComposedConnectionDetails/composition.yaml
+++ b/example/functions/getComposedConnectionDetails/composition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: example-function-get-composed-connection-details
+  name: useraccesskeys-go-templating
 spec:
   compositeTypeRef:
     apiVersion: example.crossplane.io/v1beta1
@@ -18,32 +18,52 @@ spec:
         inline:
           template: |
             ---
-            {{ $flexServerResourceName := "flexServer" }}
-            # Create an initial composed resource whose connection details we will retrieve
-            apiVersion: dbforpostgresql.azure.upbound.io/v1beta1
-            kind: FlexibleServer
+            apiVersion: iam.aws.m.upbound.io/v1beta1
+            kind: User
             metadata:
               annotations:
-                {{ setResourceNameAnnotation $flexServerResourceName }}
-                gotemplating.fn.crossplane.io/ready: "False"
+                {{ setResourceNameAnnotation "user" }}
             spec:
-              forProvider:
-                storageMb: 32768
-              providerConfigRef:
-                name: my-provider-cfg
+              forProvider: {}
             ---
-            # Use getComposedConnectionDetails to retrieve the connection details of "flexServer"
-            {{ $flexServerCD := getComposedConnectionDetails . $flexServerResourceName }}
-
-            apiVersion: dbforpostgresql.azure.upbound.io/v1beta1
-            kind: FlexibleServerConfiguration
+            apiVersion: iam.aws.m.upbound.io/v1beta1
+            kind: AccessKey
             metadata:
               annotations:
-                {{ setResourceNameAnnotation "flexServerConfig" }}
-                gotemplating.fn.crossplane.io/ready: "False"
+                {{ setResourceNameAnnotation "accesskey-0" }}
             spec:
               forProvider:
-                # Populate the field using the connection details of the retrieved resource
-                serverHost: {{ index $flexServerCD "host" }}
-              providerConfigRef:
-                name: my-provider-cfg
+                userSelector:
+                  matchControllerRef: true
+              writeConnectionSecretToRef:
+                name: {{ $.observed.composite.resource.metadata.name }}-accesskey-secret-0
+            ---
+            apiVersion: iam.aws.m.upbound.io/v1beta1
+            kind: AccessKey
+            metadata:
+              annotations:
+                {{ setResourceNameAnnotation "accesskey-1" }}
+            spec:
+              forProvider:
+                userSelector:
+                  matchControllerRef: true
+              writeConnectionSecretToRef:
+                name: {{ $.observed.composite.resource.metadata.name }}-accesskey-secret-1
+            ---
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: {{ dig "spec" "writeConnectionSecretToRef" "name" "" $.observed.composite.resource }}
+              annotations:
+                {{ setResourceNameAnnotation "connection-secret" }}
+            {{ if eq $.observed.resources nil }}
+            data: {}
+            {{ else }}
+            {{ $accesskey0 := getComposedConnectionDetails . "accesskey-0" }}
+            {{ $accesskey1 := getComposedConnectionDetails . "accesskey-1" }}
+            data:
+              user-0: {{ index $accesskey0 "username" }}
+              user-1: {{ index $accesskey1 "username" }}
+              password-0: {{ index $accesskey0 "password" }}
+              password-1: {{ index $accesskey1 "password" }}
+            {{ end }}

--- a/example/functions/getComposedConnectionDetails/functions.yaml
+++ b/example/functions/getComposedConnectionDetails/functions.yaml
@@ -1,0 +1,12 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-go-templating:v0.12.0
+---
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec: {}

--- a/example/functions/getComposedConnectionDetails/xr.yaml
+++ b/example/functions/getComposedConnectionDetails/xr.yaml
@@ -1,0 +1,5 @@
+apiVersion: example.crossplane.io/v1beta1
+kind: XR
+metadata:
+  name: example
+spec: {}

--- a/example/functions/getComposedConnectionDetails/xr.yaml
+++ b/example/functions/getComposedConnectionDetails/xr.yaml
@@ -2,4 +2,7 @@ apiVersion: example.crossplane.io/v1beta1
 kind: XR
 metadata:
   name: example
-spec: {}
+  namespace: default
+spec:
+  writeConnectionSecretToRef:
+    name: example-connection-secret

--- a/function_maps.go
+++ b/function_maps.go
@@ -31,6 +31,7 @@ func getFunctions() []template.FuncMap {
 			"setResourceNameAnnotation":    setResourceNameAnnotation,
 			"getComposedResource":          getComposedResource,
 			"getCompositeResource":         getCompositeResource,
+			"getComposedConnectionDetails": getComposedConnectionDetails,
 			"getExtraResources":            getExtraResources,
 			"getExtraResourcesFromContext": getExtraResourcesFromContext,
 			"getCredentialData":            getCredentialData,
@@ -138,6 +139,16 @@ func getCompositeResource(req map[string]any) map[string]any {
 	}
 
 	return cr
+}
+
+func getComposedConnectionDetails(req map[string]any, name string) map[string]any {
+	var cd map[string]any
+	path := fmt.Sprintf("observed.resources[%s]connectionDetails", name)
+	if err := fieldpath.Pave(req).GetValueInto(path, &cd); err != nil {
+		return nil
+	}
+
+	return cd
 }
 
 func getExtraResources(req map[string]any, name string) []any {

--- a/function_maps_test.go
+++ b/function_maps_test.go
@@ -499,6 +499,96 @@ func Test_getCompositeResource(t *testing.T) {
 	}
 }
 
+func Test_getComposedConnectionDetails(t *testing.T) {
+	type args struct {
+		req  map[string]any
+		name string
+	}
+
+	type want struct {
+		rsp map[string]any
+	}
+
+	connectionDetails := map[string]any{
+		"username": "dXNlcg==",
+		"password": "cGFzcw==",
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"RetrieveConnectionDetails": {
+			reason: "Should successfully retrieve connection details for a composed resource",
+			args: args{
+				req: map[string]any{
+					"observed": map[string]any{
+						"resources": map[string]any{
+							"my-resource": map[string]any{
+								"connectionDetails": connectionDetails,
+							},
+						},
+					},
+				},
+				name: "my-resource",
+			},
+			want: want{rsp: connectionDetails},
+		},
+		"RetrieveConnectionDetailsWithDots": {
+			reason: "Should successfully retrieve connection details when identifier contains dots",
+			args: args{
+				req: map[string]any{
+					"observed": map[string]any{
+						"resources": map[string]any{
+							"my.resource": map[string]any{
+								"connectionDetails": connectionDetails,
+							},
+						},
+					},
+				},
+				name: "my.resource",
+			},
+			want: want{rsp: connectionDetails},
+		},
+		"MissingConnectionDetails": {
+			reason: "Should return nil if the resource has no connectionDetails",
+			args: args{
+				req: map[string]any{
+					"observed": map[string]any{
+						"resources": map[string]any{
+							"my-resource": map[string]any{},
+						},
+					},
+				},
+				name: "my-resource",
+			},
+			want: want{rsp: nil},
+		},
+		"ResourceNotFound": {
+			reason: "Should return nil if the resource is not found",
+			args: args{
+				req: map[string]any{
+					"observed": map[string]any{
+						"resources": map[string]any{},
+					},
+				},
+				name: "my-resource",
+			},
+			want: want{rsp: nil},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := getComposedConnectionDetails(tc.args.req, tc.args.name)
+			if diff := cmp.Diff(tc.want.rsp, got); diff != "" {
+				t.Errorf("%s\ngetComposedConnectionDetails(...): -want rsp, +got rsp:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
 func Test_getExtraResources(t *testing.T) {
 	type args struct {
 		req  map[string]any


### PR DESCRIPTION
### Description of your changes

Adds a new `getComposedConnectionDetails(req, name)` helper that returns the `connectionDetails` map for a named composed resource, parallel to the existing `getComposedResource` helper. Avoids having to drill into `observed.resources` manually in templates.

Also adds an example showing the function used to aggregate IAM AccessKey connection details into a Secret, and adds an entry to the README functions table.

> **Note:** Connection details in observed state cannot currently be mocked with `crossplane render`. See [crossplane/crossplane#4808](https://github.com/crossplane/crossplane/issues/4808) for related upstream work.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute