### PR TITLE
fix: allow setting the max recv size via envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ overridden by the `--default-options` CLI flag or the `FUNCTION_GO_TEMPLATING_DE
 environment variable.  Setting the default-options to "missingkey=error" will cause the template
 engine to return an error when a missing key is detected, instead of setting the value to "<no value>".
 
+The maximum size of received messages (in MB) defaults to `4`. This can be overridden by the
+`--max-recv-message-size` CLI flag or the `FUNCTION_GO_TEMPLATING_MAX_RECV_MESSAGE_SIZE`
+environment variable.
+
 ### Connection Details
 
 #### v1 Composite Resources (Legacy)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type CLI struct {
 	TLSCertsDir        string `env:"TLS_SERVER_CERTS_DIR"                                                                           help:"Directory containing server certs (tls.key, tls.crt) and the CA used to verify client certificates (ca.crt)"`
 	Insecure           bool   `help:"Run without mTLS credentials. If you supply this flag --tls-server-certs-dir will be ignored."`
 	TTL                string `default:"${defaultTTL}"                                                                              help:"Function global setting for response TTL."`
-	MaxRecvMessageSize int    `default:"4"                                                                                          help:"Maximum size of received messages in MB."`
+	MaxRecvMessageSize int    `default:"4"                                                                                          env:"FUNCTION_GO_TEMPLATING_MAX_RECV_MESSAGE_SIZE"                                                                 help:"Maximum size of received messages in MB."`
 	DefaultSource      string `default:""                                                                                           env:"FUNCTION_GO_TEMPLATING_DEFAULT_SOURCE"                                                                        help:"Default template source to use when input is not provided to the function."`
 	DefaultOptions     string `default:""                                                                                           env:"FUNCTION_GO_TEMPLATING_DEFAULT_OPTIONS"                                                                       help:"Comma-separated default template options to use when input is not provided to the function."`
 }


### PR DESCRIPTION
### Description of your changes

Exposes a new environment variable `FUNCTION_GO_TEMPLATING_MAX_RECV_MESSAGE_SIZE` to control the maximum grpc message size for this function.

Fixes #591 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
