### PR TITLE
fix(security): remediate CVE vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
   GOLANGCI_VERSION: 'v2.4.0'
   DOCKER_BUILDX_VERSION: 'v0.23.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-go-templating
 
-go 1.25.11
+go 1.25.12
 
 require (
 	dario.cat/mergo v1.0.2
@@ -86,7 +86,7 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:Q9HWtNeE7tM9npdIsEvqXj1QJIvVoeAV3rtXtS715Cw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 h1:tEkOQcXgF6dH1G+MVKZrfpYvozGrzb91k6ha7jireSM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

This PR fixes CVE vulnerabilities identified by security scanning.

## Vulnerabilities Fixed

| CVE/GHSA | Severity | Package | Fixed Version |
|----------|----------|---------|---------------|
| GO-2026-5856 | Medium | stdlib (go1.25.11) | go1.25.12 |
| GO-2026-4970 | High | stdlib (go1.25.11) | go1.25.12 |
| GHSA-hrxh-6v49-42gf | High | google.golang.org/grpc v1.81.1 | v1.82.1 |

## Changes Made

- Updated Go version from 1.25.11 to 1.25.12 in go.mod
- Updated google.golang.org/grpc from v1.81.1 to v1.82.1 in go.mod
- Updated GO_VERSION in .github/workflows/ci.yml to 1.25.12
- Ran go mod tidy to update dependencies

## References

- https://pkg.go.dev/vuln/GO-2026-5856
- https://pkg.go.dev/vuln/GO-2026-4970
- https://github.com/advisories/GHSA-hrxh-6v49-42gf

## Verification

- [x] Rescanned with \`cve-scan\` skill after fixes
- [x] All listed vulnerabilities resolved