### PR TITLE
fix(renovate): match ARG GO_VERSION in Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
       "managerFilePatterns": ["/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/", "Dockerfile"],
       "matchStrings": [
         "GO_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n",
-        "^ARG GO_VERSION=(?<currentValue>.*?)"
+        "ARG GO_VERSION=(?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go",


### PR DESCRIPTION
### Description of your changes

The Dockerfile half of the Go custom manager added in #606 never produced a dependency. Renovate compiles `matchStrings` with the `g` flag only (`regEx(matchString, 'g')` in `lib/modules/manager/custom/regex/strategies.ts`), so the leading `^` anchored to the start of the file rather than the start of a line, and `ARG GO_VERSION=` sits a few lines down. Even on a match the lazy group had nothing following it, so it would have captured the empty string.

This drops the anchor and terminates on a newline, as the sibling `GO_VERSION:` pattern already does. Verified against this repo's Dockerfile with the `g` flag: the old pattern yields 0 matches, the new one captures `1`.

Heads-up for reviewers: this makes the manager live, so Renovate will start proposing Go bumps for the Dockerfile ARG. Here the ARG is `1`, so expect a PR proposing a concrete version — if keeping the floating major is deliberate, this repo wants an `ignore` rule rather than the matcher staying broken.

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~~Added or updated unit tests for my change.~~ (renovate configuration only)

[contribution process]: https://git.io/fj2m9
