### PR TITLE
Accept "Unknown" as alias for "Unspecified" ready annotation value

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -63,6 +63,10 @@ const (
 	annotationKeyReady                   = "gotemplating.fn.crossplane.io/ready"
 	annotationKeyTTL                     = "gotemplating.fn.crossplane.io/ttl"
 
+	// readyStatusUnknown is the Kubernetes condition status value
+	// (corev1.ConditionUnknown) that corresponds to resource.ReadyUnspecified.
+	readyStatusUnknown = "Unknown"
+
 	metaAPIVersion = "meta.gotemplating.fn.crossplane.io/v1alpha1"
 )
 
@@ -234,6 +238,14 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		var ready *resource.Ready
 		if cd.Resource.GetAPIVersion() != metaAPIVersion {
 			if v, found := cd.Resource.GetAnnotations()[annotationKeyReady]; found {
+				// Kubernetes condition status uses "Unknown" where this
+				// function uses "Unspecified". Accept "Unknown" as an alias
+				// so users can pass a resource's condition status straight
+				// through, e.g. via getResourceCondition.
+				if v == readyStatusUnknown {
+					v = string(resource.ReadyUnspecified)
+				}
+
 				if v != string(resource.ReadyTrue) && v != string(resource.ReadyUnspecified) && v != string(resource.ReadyFalse) {
 					response.Fatal(rsp, errors.Errorf("invalid function input: invalid %q annotation value %q: must be True, False, or Unspecified", annotationKeyReady, v))
 					return rsp, nil

--- a/fn_test.go
+++ b/fn_test.go
@@ -52,6 +52,7 @@ metadata:
 	xrWithReadyTrue                = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"True"},"name":"cool-xr"},"spec":{"count":2}}`
 	xrWithReadyFalse               = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"False"},"name":"cool-xr"},"spec":{"count":2}}`
 	xrWithReadyUnspecified         = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"Unspecified"},"name":"cool-xr"},"spec":{"count":2}}`
+	xrWithReadyUnknown             = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"Unknown"},"name":"cool-xr"},"spec":{"count":2}}`
 	xrWithReadyWrong               = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"wrongValue"},"name":"cool-xr"},"spec":{"count":2}}`
 	xrWithReadyTrueAndResourceName = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/composition-resource-name":"xr-as-composed","gotemplating.fn.crossplane.io/ready":"True"},"name":"cool-xr"},"spec":{"count":2}}`
 	xrWithReadyTrueAndStatus       = `{"apiVersion":"example.org/v1","kind":"XR","metadata":{"annotations":{"gotemplating.fn.crossplane.io/ready":"True"},"name":"cool-xr"},"spec":{"count":2},"status":{"phase":"Ready","message":"Composite resource is ready"}}`
@@ -1410,6 +1411,39 @@ func TestRunFunction(t *testing.T) {
 						&v1beta1.GoTemplate{
 							Source: v1beta1.InlineSource,
 							Inline: &v1beta1.TemplateSourceInline{Template: xrWithReadyUnspecified},
+						}),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(xr),
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(xr),
+							Ready:    0,
+						},
+					},
+				},
+			},
+		},
+		"CompositeResourceReadyUnknownAlias": {
+			reason: "The Function should treat an \"Unknown\" ready annotation value, e.g. from a Kubernetes condition status, as an alias for Unspecified.",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: xrWithReadyUnknown},
 						}),
 					Observed: &fnv1.State{
 						Composite: &fnv1.Resource{


### PR DESCRIPTION
### Description of your changes

The `gotemplating.fn.crossplane.io/ready` annotation only accepted `"True"`, `"False"`, or `"Unspecified"`. Kubernetes condition statuses, however, use `"True"`, `"False"`, or `"Unknown"` (`corev1.ConditionUnknown`), which made it cumbersome to pass a resource's condition status straight through to the ready annotation, e.g.:

```
gotemplating.fn.crossplane.io/ready: {{ (getResourceCondition "Ready" $resource).Status }}
```

Users hit a fatal error instead: `invalid function input: invalid "gotemplating.fn.crossplane.io/ready" annotation value "Unknown": must be True, False, or Unspecified`, and then had to write a conditional to translate `"Unknown"` to `"Unspecified"` themselves.

This change treats `"Unknown"` as an alias for `"Unspecified"` when parsing the ready annotation in `RunFunction`, rewriting it before the existing validation and `resource.Ready` conversion run. This resolves the annotation-value mismatch without changing the underlying `resource.Ready` enum from `function-sdk-go` (which is out of scope and used more broadly across Crossplane), so it does not affect any comparisons against `resource.ReadyUnspecified` elsewhere. Behavior for previously valid annotation values (`"True"`, `"False"`, `"Unspecified"`) is unchanged; this only accepts an additional input value that previously caused a fatal error.

Added a unit test (`CompositeResourceReadyUnknownAlias` in `fn_test.go`) mirroring the existing `CompositeResourceReadyUnspecified` test but using an `"Unknown"` annotation value. Verified the fix by reverting `fn.go` with the new test kept in place, confirming it reproduces the reported fatal error, then re-applying the fix and confirming the test passes. Also ran `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, `golangci-lint run ./...` (0 issues), and `go mod tidy` (no diff).

Fixes #461

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute

---
AI assistance: this change was drafted with Claude Code.