### PR TITLE
fix(extraresources): preserve namespace when matching by labels

### DIFF
--- a/extraresources.go
+++ b/extraresources.go
@@ -44,6 +44,11 @@ func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1.ResourceSelector 
 		ApiVersion: e.APIVersion,
 		Kind:       e.Kind,
 	}
+
+	if e.Namespace != "" {
+		out.Namespace = &e.Namespace
+	}
+
 	if e.MatchName == "" {
 		out.Match = &fnv1.ResourceSelector_MatchLabels{
 			MatchLabels: &fnv1.MatchLabels{Labels: e.MatchLabels},
@@ -53,10 +58,6 @@ func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1.ResourceSelector 
 
 	out.Match = &fnv1.ResourceSelector_MatchName{
 		MatchName: e.MatchName,
-	}
-
-	if e.Namespace != "" {
-		out.Namespace = &e.Namespace
 	}
 	return out
 }

--- a/extraresources_test.go
+++ b/extraresources_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
+)
+
+func TestToResourceSelector(t *testing.T) {
+	ns := "test-namespace"
+	name := "test-name"
+
+	cases := map[string]struct {
+		reason string
+		req    ExtraResourcesRequirement
+		want   *fnv1.ResourceSelector
+	}{
+		"MatchLabelsWithNamespace": {
+			reason: "Namespace must be set on the selector when matching by labels, not just when matching by name",
+			req: ExtraResourcesRequirement{
+				APIVersion:  "gateway.networking.k8s.io/v1",
+				Kind:        "HTTPRoute",
+				Namespace:   ns,
+				MatchLabels: map[string]string{"routetype": "prj-hostname"},
+			},
+			want: &fnv1.ResourceSelector{
+				ApiVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+				Namespace:  &ns,
+				Match: &fnv1.ResourceSelector_MatchLabels{
+					MatchLabels: &fnv1.MatchLabels{Labels: map[string]string{"routetype": "prj-hostname"}},
+				},
+			},
+		},
+		"MatchLabelsWithoutNamespace": {
+			reason: "Namespace must remain unset when matching by labels for a cluster-scoped resource",
+			req: ExtraResourcesRequirement{
+				APIVersion:  "gateway.networking.k8s.io/v1",
+				Kind:        "HTTPRoute",
+				MatchLabels: map[string]string{"routetype": "prj-hostname"},
+			},
+			want: &fnv1.ResourceSelector{
+				ApiVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+				Match: &fnv1.ResourceSelector_MatchLabels{
+					MatchLabels: &fnv1.MatchLabels{Labels: map[string]string{"routetype": "prj-hostname"}},
+				},
+			},
+		},
+		"MatchNameWithNamespace": {
+			reason: "Namespace must still be set on the selector when matching by name",
+			req: ExtraResourcesRequirement{
+				APIVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+				Namespace:  ns,
+				MatchName:  name,
+			},
+			want: &fnv1.ResourceSelector{
+				ApiVersion: "gateway.networking.k8s.io/v1",
+				Kind:       "HTTPRoute",
+				Namespace:  &ns,
+				Match: &fnv1.ResourceSelector_MatchName{
+					MatchName: name,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.ToResourceSelector()
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nToResourceSelector(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/fn_test.go
+++ b/fn_test.go
@@ -67,7 +67,8 @@ metadata:
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"all-cool-resources":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{}}}}`
 	extraResourcesDuplicatedKey = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"another-cool-extra-resource"}}}`
-	extraResourceNamespaced = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchName":"cool-extra-resource","namespace":"default"}}}`
+	extraResourceNamespaced            = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchName":"cool-extra-resource","namespace":"default"}}}`
+	extraResourceNamespacedMatchLabels = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchLabels":{"app":"test"},"namespace":"default"}}}`
 
 	key       = "userkey/go-template"
 	path      = "testdata/templates"
@@ -1881,6 +1882,75 @@ func TestRunFunction(t *testing.T) {
 								Kind:       "ConfigMap",
 								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "cool-extra-resource",
+								},
+								Namespace: ptr.To("default"),
+							},
+						},
+					},
+				},
+			},
+		},
+		"NamespacedExtraResourceMatchLabels": {
+			reason: "Namespace must be set on the selector when matching by labels, not just when matching by name.",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: extraResourceNamespacedMatchLabels},
+						}),
+					RequiredResources: map[string]*fnv1.Resources{
+						"cool-extra-resource": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "cool-extra-resource", "namespace": "default"}, "data": {"a": "b"}}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Context: resource.MustStructJSON(
+						`{
+							"apiextensions.crossplane.io/extra-resources": {
+								"cool-extra-resource": {
+								    "items": [
+									    {
+											"resource": {
+												"apiVersion": "v1",
+												"kind": "ConfigMap",
+												"metadata": {
+													"name": "cool-extra-resource",
+													"namespace": "default"
+												},
+												"data": {
+													"a": "b"
+												}
+											}
+										}
+									]
+								}
+							}
+						}`,
+					),
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON("{}"),
+						},
+					},
+					Requirements: &fnv1.Requirements{
+						Resources: map[string]*fnv1.ResourceSelector{
+							"cool-extra-resource": {
+								ApiVersion: "v1",
+								Kind:       "ConfigMap",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{"app": "test"},
+									},
 								},
 								Namespace: ptr.To("default"),
 							},


### PR DESCRIPTION
### Description of your changes

`ToResourceSelector` converts an `ExtraResourcesRequirement` into a `fnv1.ResourceSelector`, but only copied the `Namespace` field onto the selector inside the `matchName` branch. `Namespace` is a top-level field on the proto `ResourceSelector`, independent of the match oneof (`matchLabels` vs `matchName`), so when a requirement combined `matchLabels` with a namespace, the namespace was silently dropped and the query matched labelled resources across all namespaces instead of the requested one. This reproduces the exact behavior reported in the issue: HTTPRoutes selected by `matchLabels` with a namespace set came back from every namespace, not just the specified one.

The fix moves the namespace assignment above the `matchLabels`/`matchName` branch so it is applied to both selector types instead of only `matchName`.

Added `extraresources_test.go` with `TestToResourceSelector`, covering `matchLabels`+namespace (the bug scenario), `matchLabels` without a namespace (cluster-scoped, must remain unset), and `matchName`+namespace (regression guard for the previously-working path). Ran `go test -v -cover ./...`, which passed (82.9% coverage); confirmed via `git stash` that the `matchLabels`+namespace case fails against the pre-fix code and passes with the fix. Also ran `go build ./...`, `go vet ./...`, `go mod tidy` (no diff), and `golangci-lint run ./...` at v2.4.0 (the version pinned in this repo's CI workflow), all with no issues. User-visible behavior for `matchName` selectors is unchanged; the only behavior change is that `matchLabels` selectors now honor the namespace field as documented, narrowing results to the requested namespace instead of matching cluster-wide.

Fixes #597

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute

---
AI assistance: this change was drafted with Claude Code.