### PR TITLE
fix: move namespace assignment upfront, so it is done for matchLabels+matchName

### DIFF
--- a/extraresources.go
+++ b/extraresources.go
@@ -44,6 +44,11 @@ func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1.ResourceSelector 
 		ApiVersion: e.APIVersion,
 		Kind:       e.Kind,
 	}
+
+	if e.Namespace != "" {
+		out.Namespace = &e.Namespace
+	}
+
 	if e.MatchName == "" {
 		out.Match = &fnv1.ResourceSelector_MatchLabels{
 			MatchLabels: &fnv1.MatchLabels{Labels: e.MatchLabels},
@@ -53,10 +58,6 @@ func (e *ExtraResourcesRequirement) ToResourceSelector() *fnv1.ResourceSelector 
 
 	out.Match = &fnv1.ResourceSelector_MatchName{
 		MatchName: e.MatchName,
-	}
-
-	if e.Namespace != "" {
-		out.Namespace = &e.Namespace
 	}
 	return out
 }

--- a/fn_test.go
+++ b/fn_test.go
@@ -68,7 +68,8 @@ metadata:
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"all-cool-resources":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchLabels":{}}}}`
 	extraResourcesDuplicatedKey = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"cool-extra-resource"}}}
 {"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"example.org/v1","kind":"CoolExtraResource","matchName":"another-cool-extra-resource"}}}`
-	extraResourceNamespaced = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchName":"cool-extra-resource","namespace":"default"}}}`
+	extraResourceNamespaced            = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchName":"cool-extra-resource","namespace":"default"}}}`
+	extraResourceNamespacedMatchLabels = `{"apiVersion":"meta.gotemplating.fn.crossplane.io/v1alpha1","kind":"ExtraResources","requirements":{"cool-extra-resource":{"apiVersion":"v1","kind":"ConfigMap","matchLabels":{"app":"test"},"namespace":"default"}}}`
 
 	key       = "userkey/go-template"
 	path      = "testdata/templates"
@@ -1915,6 +1916,74 @@ func TestRunFunction(t *testing.T) {
 								Kind:       "ConfigMap",
 								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "cool-extra-resource",
+								},
+								Namespace: ptr.To("default"),
+							},
+						},
+					},
+				},
+			},
+		},
+		"NamespacedExtraResourceMatchLabels": {
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Input: resource.MustStructObject(
+						&v1beta1.GoTemplate{
+							Source: v1beta1.InlineSource,
+							Inline: &v1beta1.TemplateSourceInline{Template: extraResourceNamespacedMatchLabels},
+						}),
+					RequiredResources: map[string]*fnv1.Resources{
+						"cool-extra-resource": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "cool-extra-resource", "namespace": "default"}, "data": {"a": "b"}}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Context: resource.MustStructJSON(
+						`{
+							"apiextensions.crossplane.io/extra-resources": {
+								"cool-extra-resource": {
+								    "items": [
+									    {
+											"resource": {
+												"apiVersion": "v1",
+												"kind": "ConfigMap",
+												"metadata": {
+													"name": "cool-extra-resource",
+													"namespace": "default"
+												},
+												"data": {
+													"a": "b"
+												}
+											}
+										}
+									]
+								}
+							}
+						}`,
+					),
+					Desired: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON("{}"),
+						},
+					},
+					Requirements: &fnv1.Requirements{
+						Resources: map[string]*fnv1.ResourceSelector{
+							"cool-extra-resource": {
+								ApiVersion: "v1",
+								Kind:       "ConfigMap",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{"app": "test"},
+									},
 								},
 								Namespace: ptr.To("default"),
 							},


### PR DESCRIPTION
### Description of your changes

Namespace was silently dropped when using `matchLabels` with `ExtraResources`. Move the namespace assignment up, so we do it before either `matchLabels` or `matchName`.

Fixes #600 
Fixes #597 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
